### PR TITLE
Eip-191 conform signed messages

### DIFF
--- a/contracts/crypto/MessageGenerator.sol
+++ b/contracts/crypto/MessageGenerator.sol
@@ -2,6 +2,8 @@
 // Copyright (c) 2021 Divergent Technologies Ltd (github.com/divergencetech)
 pragma solidity >=0.8.0 <0.9.0;
 
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
 /**
 @title MessageGenerator
 @notice Generates messages that can be signed off-chain using ECDSA. 
@@ -9,7 +11,7 @@ Corresponding can later be verified on-chain using {SignatureChecker}.
  */
 library MessageGenerator {
     /**
-    @notice Generates a message for a given data input.
+    @notice Generates an EIP-191 conform message for a given data input.
     @dev For multiple data fields, a standard concatenation using 
     `abi.encodePacked` is commonly used to build data.
      */
@@ -18,7 +20,7 @@ library MessageGenerator {
         pure
         returns (bytes32)
     {
-        return keccak256(data);
+        return ECDSA.toEthSignedMessageHash(keccak256(data));
     }
 
     /**

--- a/contracts/crypto/MessageGenerator.sol
+++ b/contracts/crypto/MessageGenerator.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021 Divergent Technologies Ltd (github.com/divergencetech)
+pragma solidity >=0.8.0 <0.9.0;
+
+/**
+@title MessageGenerator
+@notice Generates messages that can be signed off-chain using ECDSA. 
+Corresponding can later be verified on-chain using {SignatureChecker}.
+ */
+library MessageGenerator {
+    /**
+    @notice Generates a message for a given data input.
+    @dev For multiple data fields, a standard concatenation using 
+    `abi.encodePacked` is commonly used to build data.
+     */
+    function generateMessage(bytes memory data)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(data);
+    }
+
+    /**
+    @notice Generates a message for a given address.
+     */
+    function generateMessage(address address_) internal pure returns (bytes32) {
+        return generateMessage(abi.encodePacked(address_));
+    }
+}

--- a/contracts/crypto/SignatureChecker.sol
+++ b/contracts/crypto/SignatureChecker.sol
@@ -14,11 +14,11 @@ library SignatureChecker {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     /**
-    @notice Requires that the nonce has not been used previously and that the
+    @notice Requires that the message has not been used previously and that the
     recovered signer is contained in the signers AddressSet.
     @param signers Set of addresses from which signatures are accepted.
     @param usedMessages Set of already-used messages.
-    @param signature ECDSA signature of keccak256(abi.encodePacked(data,nonce)).
+    @param signature ECDSA signature of message.
      */
     function validateSignature(
         EnumerableSet.AddressSet storage signers,

--- a/contracts/crypto/SignatureChecker.sol
+++ b/contracts/crypto/SignatureChecker.sol
@@ -37,10 +37,10 @@ library SignatureChecker {
     */
     function validateSignature(
         EnumerableSet.AddressSet storage signers,
-        bytes32 hash,
+        bytes32 message,
         bytes calldata signature
     ) internal view {
-        _validate(signers, hash, signature);
+        _validate(signers, message, signature);
     }
 
     /**

--- a/contracts/crypto/SignatureChecker.sol
+++ b/contracts/crypto/SignatureChecker.sol
@@ -17,19 +17,18 @@ library SignatureChecker {
     @notice Requires that the nonce has not been used previously and that the
     recovered signer is contained in the signers AddressSet.
     @param signers Set of addresses from which signatures are accepted.
-    @param usedNonces Set of already-used nonces.
+    @param usedMessages Set of already-used messages.
     @param signature ECDSA signature of keccak256(abi.encodePacked(data,nonce)).
      */
     function validateSignature(
         EnumerableSet.AddressSet storage signers,
-        bytes memory data,
-        bytes32 nonce,
+        bytes32 message,
         bytes calldata signature,
-        mapping(bytes32 => bool) storage usedNonces
+        mapping(bytes32 => bool) storage usedMessages
     ) internal {
-        require(!usedNonces[nonce], "SignatureChecker: Nonce already used");
-        usedNonces[nonce] = true;
-        _validate(signers, keccak256(abi.encodePacked(data, nonce)), signature);
+        require(!usedMessages[message], "SignatureChecker: Message already used");
+        usedMessages[message] = true;
+        _validate(signers, message, signature);
     }
 
     /**
@@ -42,19 +41,6 @@ library SignatureChecker {
         bytes calldata signature
     ) internal view {
         _validate(signers, hash, signature);
-    }
-
-    /**
-    @notice Hashes addr and requires that the recovered signer is contained in
-    the signers AddressSet.
-    @dev Equivalent to validate(sha3(addr), signature);
-     */
-    function validateSignature(
-        EnumerableSet.AddressSet storage signers,
-        address addr,
-        bytes calldata signature
-    ) internal view {
-        _validate(signers, keccak256(abi.encodePacked(addr)), signature);
     }
 
     /**

--- a/contracts/crypto/SignedAllowance.sol
+++ b/contracts/crypto/SignedAllowance.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021 Divergent Technologies Ltd (github.com/divergencetech)
+pragma solidity >=0.8.0 <0.9.0;
+
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import "./SignatureChecker.sol";
+import "./MessageGenerator.sol";
+
+/**
+@title SignedAllowance
+@notice Additional functions for EnumerableSet.Addresset that require a valid
+ECDSA signature of a standardized message, signed by any member of the set.
+@dev This is a convenience library combining the functionalities of 
+{SignatureChecker} and {MessageGenerator}.
+ */
+library SignedAllowance {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    // SignatureChecker adds additional functionality to an AddressSet, allowing
+    // for a signature from any set member.
+    using SignatureChecker for EnumerableSet.AddressSet;
+
+    /**
+    @notice Requires that the message has not been used previously and that the
+    recovered signer is contained in the signers AddressSet.
+    @param signers Set of addresses from which signatures are accepted.
+    @param usedMessages Set of already-used messages.
+    @param signature ECDSA signature of message.
+     */
+    function validateSignature(
+        EnumerableSet.AddressSet storage signers,
+        bytes memory data,
+        bytes calldata signature,
+        mapping(bytes32 => bool) storage usedMessages
+    ) internal {
+        bytes32 message = MessageGenerator.generateMessage(data);
+        return signers.validateSignature(message, signature, usedMessages);
+    }
+
+    /**
+    @notice Requires that the message has not been used previously and that the
+    recovered signer is contained in the signers AddressSet.
+     */
+    function validateSignature(
+        EnumerableSet.AddressSet storage signers,
+        bytes memory data,
+        bytes calldata signature
+    ) internal view {
+        bytes32 message = MessageGenerator.generateMessage(data);
+        return signers.validateSignature(message, signature);
+    }
+
+    /**
+    @notice Requires that the message has not been used previously and that the
+    recovered signer is contained in the signers AddressSet.
+     */
+    function validateSignature(
+        EnumerableSet.AddressSet storage signers,
+        address addr,
+        bytes calldata signature
+    ) internal view {
+        bytes32 message = MessageGenerator.generateMessage(addr);
+        return signers.validateSignature(message, signature);
+    }
+}

--- a/tests/crypto/TestableSignatureChecker.sol
+++ b/tests/crypto/TestableSignatureChecker.sol
@@ -15,7 +15,7 @@ contract TestableSignatureChecker {
     using SignatureChecker for EnumerableSet.AddressSet;
 
     EnumerableSet.AddressSet private signers;
-    mapping(bytes32 => bool) private usedNonces;
+    mapping(bytes32 => bool) private usedMessages;
 
     constructor(address[] memory _signers) {
         for (uint256 i = 0; i < _signers.length; i++) {
@@ -29,7 +29,11 @@ contract TestableSignatureChecker {
         bytes32 nonce,
         bytes calldata signature
     ) external {
-        signers.validateSignature(data, nonce, signature, usedNonces);
+        signers.validateSignature(
+            keccak256(abi.encodePacked(data, nonce)),
+            signature,
+            usedMessages
+        );
     }
 
     /// @dev Reverts if the signature is invalid.
@@ -48,7 +52,10 @@ contract TestableSignatureChecker {
         view
         returns (bool)
     {
-        signers.validateSignature(msg.sender, signature);
+        signers.validateSignature(
+            keccak256(abi.encodePacked(msg.sender)),
+            signature
+        );
         return true;
     }
 }

--- a/tests/crypto/TestableSignatureChecker.sol
+++ b/tests/crypto/TestableSignatureChecker.sol
@@ -2,8 +2,7 @@
 // Copyright (c) 2021 Divergent Technologies Ltd (github.com/divergencetech)
 pragma solidity >=0.8.0 <0.9.0;
 
-import "../../contracts/crypto/SignatureChecker.sol";
-import "../../contracts/crypto/MessageGenerator.sol";
+import "../../contracts/crypto/SignedAllowance.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 /**
@@ -11,9 +10,10 @@ import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
  */
 contract TestableSignatureChecker {
     using EnumerableSet for EnumerableSet.AddressSet;
-    // SignatureChecker adds additional functionality to an AddressSet, allowing
+
+    // SignedAllowance adds additional functionality to an AddressSet, allowing
     // for a signature from any set member.
-    using SignatureChecker for EnumerableSet.AddressSet;
+    using SignedAllowance for EnumerableSet.AddressSet;
 
     EnumerableSet.AddressSet private signers;
     mapping(bytes32 => bool) private usedMessages;
@@ -30,10 +30,11 @@ contract TestableSignatureChecker {
         bytes32 nonce,
         bytes calldata signature
     ) external {
-        bytes32 message = MessageGenerator.generateMessage(
-            abi.encodePacked(data, nonce)
+        signers.validateSignature(
+            abi.encodePacked(data, nonce),
+            signature,
+            usedMessages
         );
-        signers.validateSignature(message, signature, usedMessages);
     }
 
     /// @dev Reverts if the signature is invalid.
@@ -42,8 +43,7 @@ contract TestableSignatureChecker {
         view
         returns (bool)
     {
-        bytes32 message = MessageGenerator.generateMessage(data);
-        signers.validateSignature(message, signature);
+        signers.validateSignature(data, signature);
         return true;
     }
 
@@ -53,8 +53,7 @@ contract TestableSignatureChecker {
         view
         returns (bool)
     {
-        bytes32 message = MessageGenerator.generateMessage(msg.sender);
-        signers.validateSignature(message, signature);
+        signers.validateSignature(msg.sender, signature);
         return true;
     }
 }

--- a/tests/crypto/TestableSignatureChecker.sol
+++ b/tests/crypto/TestableSignatureChecker.sol
@@ -3,6 +3,7 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import "../../contracts/crypto/SignatureChecker.sol";
+import "../../contracts/crypto/MessageGenerator.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 /**
@@ -29,11 +30,10 @@ contract TestableSignatureChecker {
         bytes32 nonce,
         bytes calldata signature
     ) external {
-        signers.validateSignature(
-            keccak256(abi.encodePacked(data, nonce)),
-            signature,
-            usedMessages
+        bytes32 message = MessageGenerator.generateMessage(
+            abi.encodePacked(data, nonce)
         );
+        signers.validateSignature(message, signature, usedMessages);
     }
 
     /// @dev Reverts if the signature is invalid.
@@ -42,7 +42,8 @@ contract TestableSignatureChecker {
         view
         returns (bool)
     {
-        signers.validateSignature(keccak256(data), signature);
+        bytes32 message = MessageGenerator.generateMessage(data);
+        signers.validateSignature(message, signature);
         return true;
     }
 
@@ -52,10 +53,8 @@ contract TestableSignatureChecker {
         view
         returns (bool)
     {
-        signers.validateSignature(
-            keccak256(abi.encodePacked(msg.sender)),
-            signature
-        );
+        bytes32 message = MessageGenerator.generateMessage(msg.sender);
+        signers.validateSignature(message, signature);
         return true;
     }
 }

--- a/tests/crypto/crypto_test.go
+++ b/tests/crypto/crypto_test.go
@@ -125,8 +125,8 @@ func TestSingleUseSignature(t *testing.T) {
 			}
 
 			_, gotRepeat := checker.NeedsSignature(sim.Acc(0), tt.sentData, nonce, sig)
-			if diff := errdiff.Check(gotRepeat, "SignatureChecker: Nonce already used"); diff != "" {
-				t.Errorf("NeedsSignature() on second call with same nonce; %s", diff)
+			if diff := errdiff.Check(gotRepeat, "SignatureChecker: Message already used"); diff != "" {
+				t.Errorf("NeedsSignature() on second call with same message; %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
# Rationale
Switch to signed messages that conform to the EIP-191 standard.

This PR builds on #1.

# Implementation
- Solidity
  - Use OpenZeppelin's `ECDSA.toEthSignedMessageHash` to convert hashes in `MessageGenerator`
- Go
  - Port OpenZeppelin's `ECDSA.toEthSignedMessageHash`
  - Introduce a new function `EthSign` that uses conform messages
  - Use `EthSign` instead of `Sign` for message signing
  
 Should `Sign` be deprecated?