### PR TITLE
PRNG using Multiply With Carry

### DIFF
--- a/contracts/random/CSPRNG.sol
+++ b/contracts/random/CSPRNG.sol
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021 the ethier authors (github.com/divergencetech/ethier)
+pragma solidity >=0.8.9 <0.9.0;
+
+library CSPRNG {
+    /**
+    @notice A source of random numbers.
+    @dev Pointer to a 4-word buffer of {seed, counter, entropy, remaining unread
+    bits}. however, note that this is abstracted away by the API and SHOULD NOT
+    be used. This layout MUST NOT be considered part of the public API and
+    therefore not relied upon even within stable versions
+     */
+    type Source is uint256;
+
+    /// @notice Layout within the buffer. 0x00 is the seed.
+    uint256 private constant COUNTER = 0x20;
+    uint256 private constant ENTROPY = 0x40;
+    uint256 private constant REMAIN = 0x60;
+
+    /**
+    @notice Returns a new deterministic Source, differentiated only by the seed.
+    @dev Use of PRNG.Source does NOT provide any unpredictability as generated
+    numbers are entirely deterministic. Either a verifiable source of randomness
+    such as Chainlink VRF, or a commit-and-reveal protocol MUST be used if
+    unpredictability is required. The latter is only appropriate if the contract
+    owner can be trusted within the specified threat model.
+     */
+    function newSource(bytes32 seed) internal pure returns (Source src) {
+        assembly {
+            src := mload(0x40)
+            mstore(0x40, add(src, 0x80))
+            mstore(src, seed)
+        }
+        // DO NOT call _refill() on the new Source as newSource() is also used
+        // by loadSource(), which implements its own state modifications. The
+        // first call to read() on a fresh Source will induce a call to
+        // _refill().
+    }
+
+    /**
+    @dev Hashes seed||counter, placing it in the entropy word, and resets the
+    remaining bits to 256. Increments the counter BEFORE the refill (ie 0 is
+    never used) as this simplifies round-tripping with store() and loadSource()
+    because the stored counter state is the same as the one used for deriving
+    the entropy pool.
+     */
+    function _refill(Source src) private pure {
+        assembly {
+            let ctr := add(src, COUNTER)
+            mstore(ctr, add(1, mload(ctr)))
+            mstore(add(src, ENTROPY), keccak256(src, 0x40))
+            mstore(add(src, REMAIN), 256)
+        }
+    }
+
+    /**
+    @notice Returns the specified number of bits <= 256 from the Source.
+    @dev It is safe to cast the returned value to a uint<bits>.
+     */
+    function read(Source src, uint256 bits)
+        internal
+        pure
+        returns (uint256 sample)
+    {
+        require(bits <= 256, "PRNG: max 256 bits");
+
+        uint256 remain;
+        assembly {
+            remain := mload(add(src, REMAIN))
+        }
+        if (remain > bits) {
+            return readWithSufficient(src, bits);
+        }
+
+        uint256 extra = bits - remain;
+        sample = readWithSufficient(src, remain);
+        assembly {
+            sample := shl(extra, sample)
+        }
+
+        _refill(src);
+        sample = sample | readWithSufficient(src, extra);
+    }
+
+    /**
+    @notice Returns the specified number of bits, assuming that there is
+    sufficient entropy remaining. See read() for usage.
+     */
+    function readWithSufficient(Source src, uint256 bits)
+        private
+        pure
+        returns (uint256 sample)
+    {
+        assembly {
+            let pool := add(src, ENTROPY)
+            let ent := mload(pool)
+            sample := and(ent, sub(shl(bits, 1), 1))
+
+            mstore(pool, shr(bits, ent))
+            let rem := add(src, REMAIN)
+            mstore(rem, sub(mload(rem), bits))
+        }
+    }
+
+    /// @notice Returns a random boolean.
+    function readBool(Source src) internal pure returns (bool) {
+        return read(src, 1) == 1;
+    }
+
+    /**
+    @notice Returns the number of bits needed to encode n.
+    @dev Useful for calling readLessThan() multiple times with the same upper
+    bound.
+     */
+    function bitLength(uint256 n) internal pure returns (uint16 bits) {
+        assembly {
+            for {
+                let _n := n
+            } gt(_n, 0) {
+                _n := shr(1, _n)
+            } {
+                bits := add(bits, 1)
+            }
+        }
+    }
+
+    /**
+    @notice Returns a uniformly random value in [0,n) with rejection sampling.
+    @dev If the size of n is known, prefer readLessThan(Source, uint, uint16) as
+    it skips the bit counting performed by this version; see bitLength().
+     */
+    function readLessThan(Source src, uint256 n)
+        internal
+        pure
+        returns (uint256)
+    {
+        return readLessThan(src, n, bitLength(n));
+    }
+
+    /**
+    @notice Returns a uniformly random value in [0,n) with rejection sampling
+    from the range [0,2^bits).
+    @dev For greatest efficiency, the value of bits should be the smallest
+    number of bits required to capture n; if this is not known, use
+    readLessThan(Source, uint) or bitLength(). Although rejections are reduced
+    by using twice the number of bits, this increases the rate at which the
+    entropy pool must be refreshed with a call to keccak256().
+
+    TODO: benchmark higher number of bits for rejection vs hashing gas cost.
+     */
+    function readLessThan(
+        Source src,
+        uint256 n,
+        uint16 bits
+    ) internal pure returns (uint256 result) {
+        // Discard results >= n and try again because using % will bias towards
+        // lower values; e.g. if n = 13 and we read 4 bits then {13, 14, 15}%13
+        // will select {0, 1, 2} twice as often as the other values.
+        for (result = n; result >= n; result = read(src, bits)) {}
+    }
+
+    /**
+    @notice Returns the internal state of the Source.
+    @dev MUST NOT be considered part of the API and is subject to change without
+    deprecation nor warning. Only exposed for testing.
+     */
+    function state(Source src)
+        internal
+        pure
+        returns (
+            uint256 seed,
+            uint256 counter,
+            uint256 entropy,
+            uint256 remain
+        )
+    {
+        assembly {
+            seed := mload(src)
+            counter := mload(add(src, COUNTER))
+            entropy := mload(add(src, ENTROPY))
+            remain := mload(add(src, REMAIN))
+        }
+    }
+
+    /**
+    @notice Stores the state of the Source in a 2-word buffer. See loadSource().
+    @dev The layout of the stored state MUST NOT be considered part of the
+    public API, and is subject to change without warning. It is therefore only
+    safe to rely on stored Sources _within_ contracts, but not _between_ them.
+     */
+    function store(Source src, uint256[2] storage stored) internal {
+        uint256 seed;
+        // Counter will never be as high as 2^247 (because the sun will have
+        // depleted by then) and remain is in [0,256], so pack them to save 20k
+        // gas on an SSTORE.
+        uint256 packed;
+        assembly {
+            seed := mload(src)
+            packed := add(
+                shl(9, mload(add(src, COUNTER))),
+                mload(add(src, REMAIN))
+            )
+        }
+        stored[0] = seed;
+        stored[1] = packed;
+        // Not storing the entropy as it can be recalculated later.
+    }
+
+    /**
+    @notice Recreates a Source from the state stored with store().
+     */
+    function loadSource(uint256[2] storage stored)
+        internal
+        view
+        returns (Source)
+    {
+        Source src = newSource(bytes32(stored[0]));
+        uint256 packed = stored[1];
+        uint256 counter = packed >> 9;
+        uint256 remain = packed & 511;
+
+        assembly {
+            mstore(add(src, COUNTER), counter)
+            mstore(add(src, REMAIN), remain)
+
+            // Has the same effect on internal state as as _refill() then
+            // read(256-rem).
+            let ent := shr(sub(256, remain), keccak256(src, 0x40))
+            mstore(add(src, ENTROPY), ent)
+        }
+        return src;
+    }
+}

--- a/contracts/random/PRNG.sol
+++ b/contracts/random/PRNG.sol
@@ -54,9 +54,8 @@ library PRNG {
             let carryAndNumber := mload(src)
             let rand := and(carryAndNumber, MASK_128_BITS)
             let carry := shr(128, carryAndNumber)
-            let tmp := add(mul(MWC_FACTOR, rand), carry)
+            mstore(src, add(mul(MWC_FACTOR, rand), carry))
             mstore(add(src, REMAIN), 128)
-            mstore(src, tmp)
         }
     }
 

--- a/contracts/random/PRNG.sol
+++ b/contracts/random/PRNG.sol
@@ -18,6 +18,9 @@ library PRNG {
     /// @notice Layout within the buffer. 0x00 is the current (carry || number)
     uint256 private constant REMAIN = 0x20;
 
+    /// @notice Mask for the 128 least significant bits
+    uint256 private constant MASK_128_BITS = 0xffffffffffffffffffffffffffffffff;
+
     /**
     @notice Returns a new deterministic Source, differentiated only by the seed.
     @dev Use of PRNG.Source does NOT provide any unpredictability as generated
@@ -49,7 +52,7 @@ library PRNG {
     function _refill(Source src) private pure {
         assembly {
             let carryAndNumber := mload(src)
-            let rand := and(carryAndNumber, 0xffffffffffffffffffffffffffffffff)
+            let rand := and(carryAndNumber, MASK_128_BITS)
             let carry := shr(128, carryAndNumber)
             let tmp := add(mul(MWC_FACTOR, rand), carry)
             mstore(add(src, REMAIN), 128)

--- a/contracts/random/PRNG.sol
+++ b/contracts/random/PRNG.sol
@@ -13,7 +13,7 @@ library PRNG {
     type Source is uint256;
 
     uint256 private constant MWC_FACTOR = 2**128-10408;
-    uint256 private constant MWC_BASE = 2**128;
+    // uint256 private constant MWC_BASE = 2**128;
 
     /// @notice Layout within the buffer. 0x00 is the seed.
     uint256 private constant CARRY_AND_NUMBER = 0x00;
@@ -32,6 +32,7 @@ library PRNG {
             src := mload(0x40)
             mstore(0x40, add(src, 0x40))
             mstore(add(src, CARRY_AND_NUMBER), seed)
+            mstore(add(src, REMAIN), 128)
         }
         // DO NOT call _refill() on the new Source as newSource() is also used
         // by loadSource(), which implements its own state modifications. The

--- a/tests/random/TestableCSPRNG.sol
+++ b/tests/random/TestableCSPRNG.sol
@@ -2,12 +2,12 @@
 // Copyright (c) 2021 the ethier authors (github.com/divergencetech/ethier)
 pragma solidity >=0.8.0 <0.9.0;
 
-import "../../contracts/random/PRNG.sol";
+import "../../contracts/random/CSPRNG.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 
 /// @notice Testing contract that exposes functionality of the PRNG library.
-contract TestablePRNG {
-    using PRNG for PRNG.Source;
+contract TestableCSPRNG {
+    using CSPRNG for CSPRNG.Source;
     using Strings for uint256;
 
     /**
@@ -17,6 +17,8 @@ contract TestablePRNG {
     part of the public API.
      */
     struct State {
+        uint256 seed;
+        uint256 counter;
         uint256 entropy;
         uint256 remain;
     }
@@ -31,7 +33,7 @@ contract TestablePRNG {
         uint16 n
     ) private pure returns (uint256[] memory, State memory) {
         // NB! Read the documentation of PRNG re unpredictability.
-        PRNG.Source src = PRNG.newSource(seed);
+        CSPRNG.Source src = CSPRNG.newSource(seed);
 
         uint256[] memory samples = new uint256[](n);
         for (uint256 i = 0; i < n; i++) {
@@ -39,7 +41,7 @@ contract TestablePRNG {
         }
 
         State memory state;
-        (state.entropy, state.remain) = src.state();
+        (state.seed, state.counter, state.entropy, state.remain) = src.state();
 
         return (samples, state);
     }
@@ -60,9 +62,9 @@ contract TestablePRNG {
         (, state) = _sample(seed, bits, n);
     }
 
-    /// @dev Exposes PRNG.bitLength().
+    /// @dev Exposes CSPRNG.bitLength().
     function bitLength(uint256 n) public pure returns (uint256) {
-        return PRNG.bitLength(n);
+        return CSPRNG.bitLength(n);
     }
 
     /// @dev Returns n samples in [0,max).
@@ -72,11 +74,11 @@ contract TestablePRNG {
         uint16 n
     ) public pure returns (uint256[] memory) {
         // NB! Read the documentation of PRNG re unpredictability.
-        PRNG.Source src = PRNG.newSource(seed);
+        CSPRNG.Source src = CSPRNG.newSource(seed);
 
         // As all samples have the same upper bound, calculate the bit length
         // once and reuse it.
-        uint16 bits = PRNG.bitLength(max);
+        uint16 bits = CSPRNG.bitLength(max);
 
         uint256[] memory samples = new uint256[](n);
         for (uint256 i = 0; i < n; i++) {
@@ -99,24 +101,36 @@ contract TestablePRNG {
         uint16 bits,
         uint16 beforeStore
     ) public {
-        PRNG.Source src = PRNG.newSource(seed);
+        CSPRNG.Source src = CSPRNG.newSource(seed);
         for (uint256 i = 0; i < beforeStore; i++) {
             src.read(bits);
         }
 
         src.store(storedSource);
-        PRNG.Source copy = PRNG.loadSource(storedSource);
+        CSPRNG.Source copy = CSPRNG.loadSource(storedSource);
 
         // Confirm that we've actually round-tripped the internal state via
         // storage and not just copied it.
         require(
-            PRNG.Source.unwrap(src) != PRNG.Source.unwrap(copy),
+            CSPRNG.Source.unwrap(src) != CSPRNG.Source.unwrap(copy),
             "Identical Sources, not a copy"
         );
 
-        (uint256 entropy0, uint256 remain0) = src.state();
-        (uint256 entropy1, uint256 remain1) = copy.state();
+        (
+            uint256 seed0,
+            uint256 counter0,
+            uint256 entropy0,
+            uint256 remain0
+        ) = src.state();
+        (
+            uint256 seed1,
+            uint256 counter1,
+            uint256 entropy1,
+            uint256 remain1
+        ) = copy.state();
 
+        require(seed0 == seed1, "Seeds differ");
+        require(counter0 == counter1, "Counters differ");
         require(remain0 == remain1, "Remaining bits differ");
         // Test the entropy last as it's derived from the other values so a
         // revert() from one of them is more informative.

--- a/tests/random/TestablePRNG.sol
+++ b/tests/random/TestablePRNG.sol
@@ -17,8 +17,6 @@ contract TestablePRNG {
     part of the public API.
      */
     struct State {
-        uint256 seed;
-        uint256 counter;
         uint256 entropy;
         uint256 remain;
     }
@@ -41,7 +39,7 @@ contract TestablePRNG {
         }
 
         State memory state;
-        (state.seed, state.counter, state.entropy, state.remain) = src.state();
+        (state.entropy, state.remain) = src.state();
 
         return (samples, state);
     }
@@ -101,20 +99,14 @@ contract TestablePRNG {
         );
 
         (
-            uint256 seed0,
-            uint256 counter0,
             uint256 entropy0,
             uint256 remain0
         ) = src.state();
         (
-            uint256 seed1,
-            uint256 counter1,
             uint256 entropy1,
             uint256 remain1
         ) = copy.state();
 
-        require(seed0 == seed1, "Seeds differ");
-        require(counter0 == counter1, "Counters differ");
         require(remain0 == remain1, "Remaining bits differ");
         // Test the entropy last as it's derived from the other values so a
         // revert() from one of them is more informative.

--- a/tests/random/generate_test.go
+++ b/tests/random/generate_test.go
@@ -1,3 +1,3 @@
 package random
 
-//go:generate ethier gen TestablePRNG.sol TestableNextShuffler.sol
+//go:generate ethier gen TestablePRNG.sol TestableCSPRNG.sol TestableNextShuffler.sol

--- a/tests/random/prng_test.go
+++ b/tests/random/prng_test.go
@@ -9,11 +9,13 @@ import (
 
 	"github.com/divergencetech/ethier/ethtest"
 	"github.com/dustin/go-humanize"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/google/go-cmp/cmp"
 )
 
-func deploy(t *testing.T) (*ethtest.SimulatedBackend, *TestablePRNG) {
+func deployPRNG(t *testing.T) (*ethtest.SimulatedBackend, *TestablePRNG) {
 	t.Helper()
 
 	sim := ethtest.NewSimulatedBackendTB(t, 1)
@@ -25,8 +27,54 @@ func deploy(t *testing.T) (*ethtest.SimulatedBackend, *TestablePRNG) {
 	return sim, prng
 }
 
-// Abs returns the absolute value of x.
-func Abs(x int64) int64 {
+func deployCSPRNG(t *testing.T) (*ethtest.SimulatedBackend, *TestableCSPRNG) {
+	t.Helper()
+
+	sim := ethtest.NewSimulatedBackendTB(t, 1)
+	_, _, prng, err := DeployTestableCSPRNG(sim.Acc(0), sim)
+	if err != nil {
+		t.Fatalf("DeployTestablePRNG() error %v", err)
+	}
+
+	return sim, prng
+}
+
+type TestingContract interface {
+	Sample(opts *bind.CallOpts, seed [32]byte, bits uint16, n uint16) ([]*big.Int, error)
+	BitLength(opts *bind.CallOpts, n *big.Int) (*big.Int, error)
+	ReadLessThan(opts *bind.CallOpts, seed [32]byte, max *big.Int, n uint16) ([]*big.Int, error)
+	TestStoreAndLoad(opts *bind.TransactOpts, seed [32]byte, bits uint16, beforeStore uint16) (*types.Transaction, error)
+}
+
+type Implementation struct {
+	name string
+	sim  *ethtest.SimulatedBackend
+	prng TestingContract
+}
+
+func getImplementations(t *testing.T) []Implementation {
+	var impl []Implementation
+	{
+		sim, prng := deployPRNG(t)
+		impl = append(impl, Implementation{
+			name: "PRNG",
+			sim:  sim,
+			prng: prng,
+		})
+	}
+	{
+		sim, prng := deployCSPRNG(t)
+		impl = append(impl, Implementation{
+			name: "CSPRNG",
+			sim:  sim,
+			prng: prng,
+		})
+	}
+
+	return impl
+}
+
+func abs(x int64) int64 {
 	if x < 0 {
 		return -x
 	}
@@ -37,8 +85,7 @@ func normalCDF(z float64) float64 {
 	return 0.5 + 0.5*math.Erf(z/math.Sqrt2)
 }
 
-func TestRead(t *testing.T) {
-	_, prng := deploy(t)
+func TestReadProbabilistic(t *testing.T) {
 	tests := []struct {
 		seedFrom                  string
 		bitsPerSample, numSamples uint64
@@ -71,187 +118,312 @@ func TestRead(t *testing.T) {
 			var seed [32]byte
 			copy(seed[:], crypto.Keccak256([]byte(tt.seedFrom)))
 
-			samples, state, err := prng.Sample(nil, seed, uint16(tt.bitsPerSample), uint16(tt.numSamples))
+			for _, ii := range getImplementations(t) {
+				t.Run(ii.name, func(t *testing.T) {
+
+					samples, err := ii.prng.Sample(nil, seed, uint16(tt.bitsPerSample), uint16(tt.numSamples))
+					if err != nil {
+						t.Fatalf("Sample(%x, 8 bits, 1000 samples) error %v", seed, err)
+					}
+
+					var min, max, sum uint64
+					var onesCount int
+
+					numMax := (1 << tt.bitsPerSample) - 1
+					distMean := float64(numMax) / 2.
+					distVar := float64(numMax*numMax) / 12.
+
+					min = math.MaxUint64
+
+					var cusum, cusumMax int64
+
+					for i, s := range samples {
+						if !s.IsUint64() {
+							t.Fatalf("sample[%d].IsUint64() got false; want true", i)
+						}
+
+						u := s.Uint64()
+						sum += u
+						if u < min {
+							min = u
+						}
+						if u > max {
+							max = u
+						}
+
+						onesCount += bits.OnesCount64(u)
+
+						for j := uint64(0); j < tt.bitsPerSample; j++ {
+							z := 2*int64((u>>j)&1) - 1
+							cusum += z
+							abs := abs(cusum)
+							if abs > cusumMax {
+								cusumMax = abs
+							}
+						}
+					}
+
+					t.Run("MinMax", func(t *testing.T) {
+						// Extremely unlikely that neither the min nor the max are
+						// returned given the high number of samples and the small
+						// sampling spaces.
+						if min != 0 {
+							t.Errorf("Min = %d; want 0", min)
+						}
+						if want := uint64(1<<tt.bitsPerSample) - 1; max != want {
+							t.Errorf("Max = %d; want %d", max, want)
+						}
+					})
+
+					t.Run("Sum", func(t *testing.T) {
+
+						expectedSum := distMean * float64(tt.numSamples)
+						// The variance of as sum of uniform random variables in
+						// [0,sampleMax] is given by the sum of the individual variances
+						twoSigmaRelDev := 2 * math.Sqrt(distVar*float64(tt.numSamples)) / expectedSum
+
+						if dev := 1 - float64(expectedSum)/float64(sum); math.Abs(dev) > twoSigmaRelDev {
+							t.Errorf("Sum = %s deviates by %.2f%% (>%.2f%% abs = 2 sigma) from expected sum %s", humanize.Comma(int64(sum)), dev*100, twoSigmaRelDev*100, humanize.Comma(int64(expectedSum)))
+						}
+					})
+
+					t.Run("Monobit Frequency", func(t *testing.T) {
+						expectedMonocount := float64(tt.numSamples*tt.bitsPerSample) / 2
+						// Follows a binomial distribution. Variance is nSamples/4
+						twoSigmaRelDev := 2. / math.Sqrt(float64(tt.numSamples*tt.bitsPerSample))
+
+						if dev := 1 - float64(expectedMonocount)/float64(onesCount); math.Abs(dev) > twoSigmaRelDev {
+							t.Errorf("One count = %s deviates by %.2f%% (>%.2f%% abs = 2 sigma) from expected sum %s", humanize.Comma(int64(onesCount)), dev*100, twoSigmaRelDev*100, humanize.Comma(int64(expectedMonocount)))
+						}
+					})
+
+					t.Run("Monobit CUSUM", func(t *testing.T) {
+						// See Sect. 2.13 in https://nvlpubs.nist.gov/nistpubs/legacy/sp/nistspecialpublication800-22r1a.pdf
+						p := float64(1)
+						n := tt.numSamples * tt.bitsPerSample
+						z := cusumMax
+						sqrtn := math.Sqrt(float64(n))
+						kStart := int64(0.25 * (-float64(n)/float64(z) + 1))
+						kEnd := int64(0.25 * (float64(n)/float64(z) - 1))
+
+						for k := kStart; k <= kEnd; k++ {
+							p -= normalCDF(float64((4*k+1)*z)/sqrtn) - normalCDF(float64((4*k-1)*z)/sqrtn)
+						}
+
+						kStart = int64(0.25 * (-float64(n)/float64(z) - 3))
+						for k := kStart; k <= kEnd; k++ {
+							p += normalCDF(float64((4*k+3)*z)/sqrtn) - normalCDF(float64((4*k+1)*z)/sqrtn)
+						}
+
+						if p < 0.01 {
+							t.Errorf("Cusum test failed with p=%.2f < 0.01", p)
+						}
+					})
+
+				})
+
+			}
+		})
+	}
+}
+
+func TestReadInternalStatePRNG(t *testing.T) {
+	tests := []struct {
+		seedFrom                  string
+		bitsPerSample, numSamples uint64
+	}{
+		{
+			seedFrom:      "a",
+			bitsPerSample: 8,
+			numSamples:    5_000,
+		},
+		{
+			seedFrom:      "b",
+			bitsPerSample: 5,
+			numSamples:    5_000,
+		},
+		{
+			seedFrom:      "c",
+			bitsPerSample: 7,
+			numSamples:    10_000,
+		},
+		{
+			seedFrom:      "d",
+			bitsPerSample: 3,
+			numSamples:    7_500,
+		},
+	}
+
+	for _, tt := range tests {
+		name := fmt.Sprintf("seed keccak256(%q) %d samples of %d bits", tt.seedFrom, tt.numSamples, tt.bitsPerSample)
+		t.Run(name, func(t *testing.T) {
+			_, prng := deployPRNG(t)
+
+			var seed [32]byte
+			copy(seed[:], crypto.Keccak256([]byte(tt.seedFrom)))
+
+			state, err := prng.SampleState(nil, seed, uint16(tt.bitsPerSample), uint16(tt.numSamples))
 			if err != nil {
 				t.Fatalf("Sample(%x, 8 bits, 1000 samples) error %v", seed, err)
 			}
 
-			t.Run("probabilistic tests", func(t *testing.T) {
-				var min, max, sum uint64
-				var onesCount int
+			// // This test is primarily in place to confirm that the assembly
+			// // implementation works as intended when converted to a
+			// // high-level, more readable equivalent.
 
-				numMax := (1 << tt.bitsPerSample) - 1
-				distMean := float64(numMax) / 2.
-				distVar := float64(numMax*numMax) / 12.
+			seedInt := new(big.Int).SetBytes(seed[:])
+			two128 := new(big.Int).Lsh(big.NewInt(1), 128)
 
-				min = math.MaxUint64
+			// first 128 bits of seed
+			carry := new(big.Int).Rsh(seedInt, 128)
 
-				var cusum, cusumMax int64
+			// last 128 bits of seed
+			number := new(big.Int).Mod(seedInt, two128)
 
-				for i, s := range samples {
-					if !s.IsUint64() {
-						t.Fatalf("sample[%d].IsUint64() got false; want true", i)
-					}
+			factor := new(big.Int).Sub(two128, big.NewInt(10408))
 
-					u := s.Uint64()
-					sum += u
-					if u < min {
-						min = u
-					}
-					if u > max {
-						max = u
-					}
+			// Performing MWC updates
+			nRefills := (tt.numSamples * tt.bitsPerSample) / 128
+			for k := uint64(0); k < nRefills; k++ {
+				tmp := new(big.Int).Mul(factor, number)
+				tmp.Add(tmp, carry)
 
-					onesCount += bits.OnesCount64(u)
+				carry.Rsh(tmp, 128)
+				number.Mod(tmp, two128)
+			}
 
-					for j := uint64(0); j < tt.bitsPerSample; j++ {
-						z := 2*int64((u>>j)&1) - 1
-						cusum += z
-						abs := Abs(cusum)
-						if abs > cusumMax {
-							cusumMax = abs
-						}
-					}
-				}
+			carry.Lsh(carry, 128)
+			entropy := new(big.Int).Add(carry, number)
 
-				// Extremely unlikely that neither the min nor the max are
-				// returned given the high number of samples and the small
-				// sampling spaces.
-				if min != 0 {
-					t.Errorf("Min = %d; want 0", min)
-				}
-				if want := uint64(1<<tt.bitsPerSample) - 1; max != want {
-					t.Errorf("Max = %d; want %d", max, want)
-				}
+			wantState := TestablePRNGState{
+				Entropy: entropy,
+				Remain:  big.NewInt(128 - int64(tt.bitsPerSample*tt.numSamples)%128),
+			}
 
-				// Random number sum
-				{
-					expectedSum := distMean * float64(tt.numSamples)
-					// The variance of as sum of uniform random variables in
-					// [0,sampleMax] is given by the sum of the individual variances
-					twoSigmaRelDev := 2 * math.Sqrt(distVar*float64(tt.numSamples)) / expectedSum
+			if diff := cmp.Diff(wantState, state, ethtest.Comparers()...); diff != "" {
+				t.Errorf("After %d samples of %d bits each; internal state diff (-want +got):\n%s", tt.numSamples, tt.bitsPerSample, diff)
+			}
+		})
+	}
+}
 
-					if dev := 1 - float64(expectedSum)/float64(sum); math.Abs(dev) > twoSigmaRelDev {
-						t.Errorf("Sum = %s deviates by %.2f%% (>%.2f%% abs = 2 sigma) from expected sum %s", humanize.Comma(int64(sum)), dev*100, twoSigmaRelDev*100, humanize.Comma(int64(expectedSum)))
-					}
-				}
+func TestReadInternalStateCSPRNG(t *testing.T) {
+	tests := []struct {
+		seedFrom                  string
+		bitsPerSample, numSamples uint64
+	}{
+		{
+			seedFrom:      "a",
+			bitsPerSample: 8,
+			numSamples:    5_000,
+		},
+		{
+			seedFrom:      "b",
+			bitsPerSample: 5,
+			numSamples:    5_000,
+		},
+		{
+			seedFrom:      "c",
+			bitsPerSample: 7,
+			numSamples:    10_000,
+		},
+		{
+			seedFrom:      "d",
+			bitsPerSample: 3,
+			numSamples:    7_500,
+		},
+	}
 
-				// Frequency monobits
-				{
-					expectedMonocount := float64(tt.numSamples*tt.bitsPerSample) / 2
-					// Follows a binomial distribution. Variance is nSamples/4
-					twoSigmaRelDev := 2. / math.Sqrt(float64(tt.numSamples*tt.bitsPerSample))
+	for _, tt := range tests {
+		name := fmt.Sprintf("seed keccak256(%q) %d samples of %d bits", tt.seedFrom, tt.numSamples, tt.bitsPerSample)
+		t.Run(name, func(t *testing.T) {
+			_, prng := deployCSPRNG(t)
 
-					if dev := 1 - float64(expectedMonocount)/float64(onesCount); math.Abs(dev) > twoSigmaRelDev {
-						t.Errorf("One count = %s deviates by %.2f%% (>%.2f%% abs = 2 sigma) from expected sum %s", humanize.Comma(int64(onesCount)), dev*100, twoSigmaRelDev*100, humanize.Comma(int64(expectedMonocount)))
-					}
-				}
+			var seed [32]byte
+			copy(seed[:], crypto.Keccak256([]byte(tt.seedFrom)))
 
-				// Cusum
-				// See Sect. 2.13 in https://nvlpubs.nist.gov/nistpubs/legacy/sp/nistspecialpublication800-22r1a.pdf
-				{
-					p := float64(1)
-					n := tt.numSamples * tt.bitsPerSample
-					z := cusumMax
-					sqrtn := math.Sqrt(float64(n))
-					kStart := int64(0.25 * (-float64(n)/float64(z) + 1))
-					kEnd := int64(0.25 * (float64(n)/float64(z) - 1))
+			state, err := prng.SampleState(nil, seed, uint16(tt.bitsPerSample), uint16(tt.numSamples))
+			if err != nil {
+				t.Fatalf("Sample(%x, 8 bits, 1000 samples) error %v", seed, err)
+			}
 
-					for k := kStart; k <= kEnd; k++ {
-						p -= normalCDF(float64((4*k+1)*z)/sqrtn) - normalCDF(float64((4*k-1)*z)/sqrtn)
-					}
+			// This test is primarily in place to confirm that the assembly
+			// implementation works as intended when converted to a
+			// high-level, more readable equivalent.
+			wantState := TestableCSPRNGState{
+				Seed:    new(big.Int).SetBytes(seed[:]),
+				Counter: big.NewInt(int64(tt.bitsPerSample*tt.numSamples/256 + 1)),
+				Remain:  big.NewInt(256 - int64(tt.bitsPerSample*tt.numSamples)%256),
+			}
 
-					kStart = int64(0.25 * (-float64(n)/float64(z) - 3))
-					for k := kStart; k <= kEnd; k++ {
-						p += normalCDF(float64((4*k+3)*z)/sqrtn) - normalCDF(float64((4*k+1)*z)/sqrtn)
-					}
+			// PRNG increments the counter and then fills the entropy pool
+			// with keccak256(seed||counter).
+			entropy := new(big.Int).Lsh(wantState.Seed, 256)
+			entropy.Add(entropy, wantState.Counter)
+			// It's important not to use entropy.Bytes() here as we MUST
+			// have exactly 64 bytes to be hashed.
+			buf := make([]byte, 64)
+			entropy.FillBytes(buf)
+			// Some of the entropy has depleted; we know how much from
+			// Remain.
+			wantState.Entropy = new(big.Int).Rsh(
+				new(big.Int).SetBytes(crypto.Keccak256(buf)),
+				uint(256-wantState.Remain.Uint64()),
+			)
 
-					if p < 0.01 {
-						t.Errorf("Cusum test failed with p=%.2f < 0.01", p)
-					}
-				}
-			})
-
-			t.Run("internal state", func(t *testing.T) {
-				// // This test is primarily in place to confirm that the assembly
-				// // implementation works as intended when converted to a
-				// // high-level, more readable equivalent.
-
-				seedInt := new(big.Int).SetBytes(seed[:])
-				two128 := new(big.Int).Lsh(big.NewInt(1), 128)
-
-				// first 128 bits of seed
-				carry := new(big.Int).Rsh(seedInt, 128)
-
-				// last 128 bits of seed
-				number := new(big.Int).Mod(seedInt, two128)
-
-				factor := new(big.Int).Sub(two128, big.NewInt(10408))
-
-				// Performing MWC updates
-				nRefills := (tt.numSamples * tt.bitsPerSample) / 128
-				for k := uint64(0); k < nRefills; k++ {
-					tmp := new(big.Int).Mul(factor, number)
-					tmp.Add(tmp, carry)
-
-					carry.Rsh(tmp, 128)
-					number.Mod(tmp, two128)
-				}
-
-				carry.Lsh(carry, 128)
-				entropy := new(big.Int).Add(carry, number)
-
-				wantState := TestablePRNGState{
-					Entropy: entropy,
-					Remain:  big.NewInt(128 - int64(tt.bitsPerSample*tt.numSamples)%128),
-				}
-
-				if diff := cmp.Diff(wantState, state, ethtest.Comparers()...); diff != "" {
-					t.Errorf("After %d samples of %d bits each; internal state diff (-want +got):\n%s", tt.numSamples, tt.bitsPerSample, diff)
-				}
-			})
+			if diff := cmp.Diff(wantState, state, ethtest.Comparers()...); diff != "" {
+				t.Errorf("After %d samples of %d bits each; internal state diff (-want +got):\n%s", tt.numSamples, tt.bitsPerSample, diff)
+			}
 		})
 	}
 }
 
 func TestBitLength(t *testing.T) {
-	_, prng := deploy(t)
 
-	for _, in := range []uint64{0, 1, 2, 3, 4, 5, 63, 64, 127, 128, 255, 256, math.MaxUint64} {
-		want := bits.Len64(in)
+	for _, ii := range getImplementations(t) {
+		t.Run(ii.name, func(t *testing.T) {
 
-		got, err := prng.BitLength(nil, new(big.Int).SetUint64(in))
-		if err != nil {
-			t.Errorf("BitLength(%d) error %v", in, err)
-			continue
-		}
+			for _, in := range []uint64{0, 1, 2, 3, 4, 5, 63, 64, 127, 128, 255, 256, math.MaxUint64} {
+				want := bits.Len64(in)
 
-		if got.Cmp(big.NewInt(int64(want))) != 0 {
-			t.Errorf("BitLength(%d) got %d; want %d", in, got, want)
-		}
+				got, err := ii.prng.BitLength(nil, new(big.Int).SetUint64(in))
+				if err != nil {
+					t.Errorf("BitLength(%d) error %v", in, err)
+					continue
+				}
 
+				if got.Cmp(big.NewInt(int64(want))) != 0 {
+					t.Errorf("BitLength(%d) got %d; want %d", in, got, want)
+				}
+
+			}
+		})
 	}
 }
 
 func TestReadLessThan(t *testing.T) {
-	_, prng := deploy(t)
 
-	const n = uint16(1e4)
+	for _, ii := range getImplementations(t) {
+		t.Run(ii.name, func(t *testing.T) {
 
-	for _, max := range []uint64{1, 2, 3, 7, 8, 127, 128, 1023, 1024} {
-		t.Run(fmt.Sprintf("%d samples < %d", n, max), func(t *testing.T) {
-			var seed [32]byte
+			const n = uint16(1e4)
 
-			bigMax := new(big.Int).SetUint64(max)
-			got, err := prng.ReadLessThan(nil, seed, bigMax, n)
-			if err != nil {
-				t.Fatalf("ReadLessThan() error %v", err)
-			}
+			for _, max := range []uint64{1, 2, 3, 7, 8, 127, 128, 1023, 1024} {
+				t.Run(fmt.Sprintf("%d samples < %d", n, max), func(t *testing.T) {
+					var seed [32]byte
 
-			for _, s := range got {
-				if s.Cmp(bigMax) != -1 {
-					t.Errorf("ReadLessThan(%d) returned sample %d out of range", max, s)
-				}
+					bigMax := new(big.Int).SetUint64(max)
+					got, err := ii.prng.ReadLessThan(nil, seed, bigMax, n)
+					if err != nil {
+						t.Fatalf("ReadLessThan() error %v", err)
+					}
+
+					for _, s := range got {
+						if s.Cmp(bigMax) != -1 {
+							t.Errorf("ReadLessThan(%d) returned sample %d out of range", max, s)
+						}
+					}
+				})
 			}
 		})
 	}
@@ -285,10 +457,13 @@ func TestStoreAndLoad(t *testing.T) {
 		var seed [32]byte
 		seed[31] = byte(i + 1)
 
-		sim, prng := deploy(t)
+		for _, ii := range getImplementations(t) {
+			t.Run(ii.name, func(t *testing.T) {
 
-		if _, err := prng.TestStoreAndLoad(sim.Acc(0), seed, tt.bits, tt.beforeStore); err != nil {
-			t.Errorf("StoreAndLoad(%#x, %d, %d) error %v", seed, tt.bits, tt.beforeStore, err)
+				if _, err := ii.prng.TestStoreAndLoad(ii.sim.Acc(0), seed, tt.bits, tt.beforeStore); err != nil {
+					t.Errorf("StoreAndLoad(%#x, %d, %d) error %v", seed, tt.bits, tt.beforeStore, err)
+				}
+			})
 		}
 	}
 }


### PR DESCRIPTION
# Motivation
Using `keccak256` to generate pseudorandom numbers can be quite expensive and thus not feasible for some applications. Although cheaper MWC generators are not cryptographically safe, they provide suitable alternatives for many use-cases.

# Implementation Summary
- Rename the old library implementation `PRNG -> CSPRNG`
- Implement an 128bit MWC generator in the `PRNG` library
- Adapt the PRNG testing suite to cover multiple similar implementations
- Extend the testing suite by a
  - Monobit frequency test
  - Monobit cusum test