### PR TITLE
SignatureChecker: Provide interfaces to use user supplied messages

### DIFF
--- a/contracts/crypto/SignatureChecker.sol
+++ b/contracts/crypto/SignatureChecker.sol
@@ -22,7 +22,7 @@ library SignatureChecker {
     @param usedMessages Set of already-used messages.
     @param signature ECDSA signature of message.
      */
-    function validateSignature(
+    function requireValidSignature(
         EnumerableSet.AddressSet storage signers,
         bytes memory data,
         bytes calldata signature,
@@ -42,7 +42,7 @@ library SignatureChecker {
     recovered signer is contained in the signers AddressSet.
     @dev Convenience wrapper for message generation + signature verification.
      */
-    function validateSignature(
+    function requireValidSignature(
         EnumerableSet.AddressSet storage signers,
         bytes memory data,
         bytes calldata signature
@@ -57,7 +57,7 @@ library SignatureChecker {
     @dev Convenience wrapper for message generation from address +
     signature verification.
      */
-    function validateSignature(
+    function requireValidSignature(
         EnumerableSet.AddressSet storage signers,
         address address_,
         bytes calldata signature
@@ -70,7 +70,7 @@ library SignatureChecker {
     @notice Common validator logic, checking if the recovered signer is
     contained in the signers AddressSet.
     */
-    function validateSignature(
+    function isValidateSignature(
         EnumerableSet.AddressSet storage signers,
         bytes32 message,
         bytes calldata signature
@@ -89,7 +89,7 @@ library SignatureChecker {
         bytes calldata signature
     ) internal view {
         require(
-            validateSignature(signers, message, signature),
+            isValidateSignature(signers, message, signature),
             "SignatureChecker: Invalid signature"
         );
     }

--- a/contracts/crypto/SignatureChecker.sol
+++ b/contracts/crypto/SignatureChecker.sol
@@ -8,67 +8,103 @@ import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 /**
 @title SignatureChecker
 @notice Additional functions for EnumerableSet.Addresset that require a valid
-ECDSA signature, signed by any member of the set.
+ECDSA signature of a standardized message, signed by any member of the set.
  */
 library SignatureChecker {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     /**
-    @notice Requires that the nonce has not been used previously and that the
+    @notice Requires that the message has not been used previously and that the
     recovered signer is contained in the signers AddressSet.
+    @dev Convenience wrapper for message generation + signature verification
+    + marking message as used
     @param signers Set of addresses from which signatures are accepted.
-    @param usedNonces Set of already-used nonces.
-    @param signature ECDSA signature of keccak256(abi.encodePacked(data,nonce)).
+    @param usedMessages Set of already-used messages.
+    @param signature ECDSA signature of message.
      */
     function validateSignature(
         EnumerableSet.AddressSet storage signers,
         bytes memory data,
-        bytes32 nonce,
         bytes calldata signature,
-        mapping(bytes32 => bool) storage usedNonces
+        mapping(bytes32 => bool) storage usedMessages
     ) internal {
-        require(!usedNonces[nonce], "SignatureChecker: Nonce already used");
-        usedNonces[nonce] = true;
-        _validate(signers, keccak256(abi.encodePacked(data, nonce)), signature);
+        bytes32 message = generateMessage(data);
+        require(
+            !usedMessages[message],
+            "SignatureChecker: Message already used"
+        );
+        usedMessages[message] = true;
+        requireValidSignature(signers, message, signature);
+    }
+
+    /**
+    @notice Requires that the message has not been used previously and that the
+    recovered signer is contained in the signers AddressSet.
+    @dev Convenience wrapper for message generation + signature verification.
+     */
+    function validateSignature(
+        EnumerableSet.AddressSet storage signers,
+        bytes memory data,
+        bytes calldata signature
+    ) internal view {
+        bytes32 message = generateMessage(data);
+        requireValidSignature(signers, message, signature);
+    }
+
+    /**
+    @notice Requires that the message has not been used previously and that the
+    recovered signer is contained in the signers AddressSet.
+    @dev Convenience wrapper for message generation from address +
+    signature verification.
+     */
+    function validateSignature(
+        EnumerableSet.AddressSet storage signers,
+        address address_,
+        bytes calldata signature
+    ) internal view {
+        bytes32 message = generateMessage(abi.encodePacked(address_));
+        requireValidSignature(signers, message, signature);
+    }
+
+    /**
+    @notice Common validator logic, checking if the recovered signer is
+    contained in the signers AddressSet.
+    */
+    function validateSignature(
+        EnumerableSet.AddressSet storage signers,
+        bytes32 message,
+        bytes calldata signature
+    ) internal view returns (bool) {
+        return signers.contains(ECDSA.recover(message, signature));
     }
 
     /**
     @notice Requires that the recovered signer is contained in the signers
     AddressSet.
+    @dev Convenience wrapper that reverts if the signature validation fails.
     */
-    function validateSignature(
+    function requireValidSignature(
         EnumerableSet.AddressSet storage signers,
-        bytes32 hash,
+        bytes32 message,
         bytes calldata signature
     ) internal view {
-        _validate(signers, hash, signature);
-    }
-
-    /**
-    @notice Hashes addr and requires that the recovered signer is contained in
-    the signers AddressSet.
-    @dev Equivalent to validate(sha3(addr), signature);
-     */
-    function validateSignature(
-        EnumerableSet.AddressSet storage signers,
-        address addr,
-        bytes calldata signature
-    ) internal view {
-        _validate(signers, keccak256(abi.encodePacked(addr)), signature);
-    }
-
-    /**
-    @notice Common validator logic, requiring that the recovered signer is
-    contained in the _signers AddressSet.
-     */
-    function _validate(
-        EnumerableSet.AddressSet storage signers,
-        bytes32 hash,
-        bytes calldata signature
-    ) private view {
         require(
-            signers.contains(ECDSA.recover(hash, signature)),
+            validateSignature(signers, message, signature),
             "SignatureChecker: Invalid signature"
         );
+    }
+
+    /**
+    @notice Generates a message for a given data input that will be signed
+    off-chain using ECDSA.
+    @dev For multiple data fields, a standard concatenation using 
+    `abi.encodePacked` is commonly used to build data.
+     */
+    function generateMessage(bytes memory data)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(data);
     }
 }

--- a/contracts/crypto/SignatureChecker.sol
+++ b/contracts/crypto/SignatureChecker.sol
@@ -59,10 +59,10 @@ library SignatureChecker {
      */
     function requireValidSignature(
         EnumerableSet.AddressSet storage signers,
-        address address_,
+        address a,
         bytes calldata signature
     ) internal view {
-        bytes32 message = generateMessage(abi.encodePacked(address_));
+        bytes32 message = generateMessage(abi.encodePacked(a));
         requireValidSignature(signers, message, signature);
     }
 

--- a/tests/crypto/TestableSignatureChecker.sol
+++ b/tests/crypto/TestableSignatureChecker.sol
@@ -29,7 +29,7 @@ contract TestableSignatureChecker {
         bytes32 nonce,
         bytes calldata signature
     ) external {
-        signers.validateSignature(
+        signers.requireValidSignature(
             abi.encodePacked(data, nonce),
             signature,
             usedMessages
@@ -42,7 +42,7 @@ contract TestableSignatureChecker {
         view
         returns (bool)
     {
-        signers.validateSignature(data, signature);
+        signers.requireValidSignature(data, signature);
         return true;
     }
 
@@ -52,7 +52,7 @@ contract TestableSignatureChecker {
         view
         returns (bool)
     {
-        signers.validateSignature(msg.sender, signature);
+        signers.requireValidSignature(msg.sender, signature);
         return true;
     }
 }

--- a/tests/crypto/TestableSignatureChecker.sol
+++ b/tests/crypto/TestableSignatureChecker.sol
@@ -15,7 +15,7 @@ contract TestableSignatureChecker {
     using SignatureChecker for EnumerableSet.AddressSet;
 
     EnumerableSet.AddressSet private signers;
-    mapping(bytes32 => bool) private usedNonces;
+    mapping(bytes32 => bool) private usedMessages;
 
     constructor(address[] memory _signers) {
         for (uint256 i = 0; i < _signers.length; i++) {
@@ -29,7 +29,11 @@ contract TestableSignatureChecker {
         bytes32 nonce,
         bytes calldata signature
     ) external {
-        signers.validateSignature(data, nonce, signature, usedNonces);
+        signers.validateSignature(
+            abi.encodePacked(data, nonce),
+            signature,
+            usedMessages
+        );
     }
 
     /// @dev Reverts if the signature is invalid.
@@ -38,11 +42,11 @@ contract TestableSignatureChecker {
         view
         returns (bool)
     {
-        signers.validateSignature(keccak256(data), signature);
+        signers.validateSignature(data, signature);
         return true;
     }
 
-    /// @dev Reverts if the signature is not valid for keccak256(msg.sender).
+    /// @dev Reverts if the signature is not valid for msg.sender.
     function needsSenderSignature(bytes calldata signature)
         external
         view

--- a/tests/crypto/crypto_test.go
+++ b/tests/crypto/crypto_test.go
@@ -125,8 +125,8 @@ func TestSingleUseSignature(t *testing.T) {
 			}
 
 			_, gotRepeat := checker.NeedsSignature(sim.Acc(0), tt.sentData, nonce, sig)
-			if diff := errdiff.Check(gotRepeat, "SignatureChecker: Nonce already used"); diff != "" {
-				t.Errorf("NeedsSignature() on second call with same nonce; %s", diff)
+			if diff := errdiff.Check(gotRepeat, "SignatureChecker: Message already used"); diff != "" {
+				t.Errorf("NeedsSignature() on second call with same message; %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
# Motivation
Solves #11
Reduces overhead compared to #1 

# Implementation Summary
- Message-type is bytes32 (typically an output of keccak256)
- For signatures that should only be usable once, we will now track the message instead of nonce
- Overloads for `validateSignature` have been introduced to validate signed messages (irrespective of message generation), allowing external message generation routines to be used if needed.
- Previous validation methods were kept as convenience wrappers for ease of use.


