### PR TITLE
Ensure that `go generate` uses repository-specific ethier binary.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "build": "go build -o build/ethier ethier/*.go",
     "generate": "PATH=\"$(readlink -f build):${PATH}\" go generate ./...",
     "testlight": "go test ./...",
-    "test": "go generate ./... && go test ./...",
-    "testverbose": "go generate ./... && go test ./... -test.v"
+    "test": "PATH=\"$(readlink -f build):${PATH}\" go generate ./... && go test ./...",
+    "testverbose": "PATH=\"$(readlink -f build):${PATH}\" go generate ./... && go test ./... -test.v"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
My end goal is to have other repositories use the `ethier` binary in their workflow, which means there can be a global installation of it, but tests must use the local one. This also doesn't require that `./build` is in the PATH.