### PR TITLE
EIP-191 conform personal signed messages

### DIFF
--- a/contracts/crypto/SignatureChecker.sol
+++ b/contracts/crypto/SignatureChecker.sol
@@ -105,6 +105,6 @@ library SignatureChecker {
         pure
         returns (bytes32)
     {
-        return keccak256(data);
+        return ECDSA.toEthSignedMessageHash(data);
     }
 }

--- a/eth/signer.go
+++ b/eth/signer.go
@@ -227,6 +227,9 @@ func (s *Signer) PersonalSignWithNonce(buf []byte) ([]byte, [32]byte, error) {
 		personal:  true,
 		withNonce: true,
 	})
+	if err != nil {
+		return nil, [32]byte{}, err
+	}
 	return sig, *nonce, err
 
 }

--- a/eth/signer.go
+++ b/eth/signer.go
@@ -117,7 +117,7 @@ func CompactSignature(rsv []byte) ([]byte, error) {
 
 // AppendRandomNonce appends random 32 bytes to the buffer, commonly used in
 // signature nonces.
-func AppendRandomNonce(buf []byte) ([]byte, [32]byte, error) {
+func appendRandomNonce(buf []byte) ([]byte, [32]byte, error) {
 	var nonce [32]byte
 	if n, err := rand.Read(nonce[:]); n != 32 || err != nil {
 		return nil, nonce, fmt.Errorf("read 32 random bytes: got %d bytes with err %v", n, err)
@@ -150,7 +150,7 @@ func (s *Signer) sign(buf []byte, opts signOpts) ([]byte, *[32]byte, error) {
 
 	if opts.withNonce {
 		var n [32]byte
-		buf, n, err = AppendRandomNonce(buf)
+		buf, n, err = appendRandomNonce(buf)
 		nonce = &n
 		if err != nil {
 			return nil, nil, err

--- a/eth/signer.go
+++ b/eth/signer.go
@@ -126,9 +126,9 @@ func appendRandomNonce(buf []byte) ([]byte, [32]byte, error) {
 	return append(buf, nonce[:]...), nonce, nil
 }
 
-// ToEthSignedMessageHash converts a given message to conform to the signed data
+// WithPersonalMessagePrefix converts a given message to conform to the signed data
 // standard according to EIP-191.
-func ToEthPersonalSignedMessage(message []byte) []byte {
+func WithPersonalMessagePrefix(message []byte) []byte {
 	prefix := []byte(fmt.Sprintf("\x19Ethereum Signed Message:\n%d", len(message)))
 	return append(prefix, message...)
 }
@@ -158,7 +158,7 @@ func (s *Signer) sign(buf []byte, opts signOpts) ([]byte, *[32]byte, error) {
 	}
 
 	if opts.personal {
-		buf = ToEthPersonalSignedMessage(buf)
+		buf = WithPersonalMessagePrefix(buf)
 	}
 
 	if !opts.raw {
@@ -207,7 +207,7 @@ func (s *Signer) Sign(buf []byte) ([]byte, error) {
 }
 
 // PersonalSign returns an EIP-191 conform personal ECDSA signature of buf
-// Convenience wrapper for s.CompactSign(toEthPersonalSignedMessage(buf))
+// Convenience wrapper for s.CompactSign(WithPersonalMessagePrefix(buf))
 func (s *Signer) PersonalSign(buf []byte) ([]byte, error) {
 	sig, _, err := s.sign(buf, signOpts{
 		raw:       false,

--- a/eth/signer.go
+++ b/eth/signer.go
@@ -100,24 +100,31 @@ func (s *Signer) Address() common.Address {
 // SHOULD be hashed first to avoid chosen-plaintext attacks. Prefer
 // Signer.Sign().
 func (s *Signer) RawSign(buf []byte) ([]byte, error) {
-	return crypto.Sign(buf, s.key)
+	sig, _, err := s.sign(buf, signOpts{
+		raw:       true,
+		compact:   false,
+		personal:  false,
+		withNonce: false,
+	})
+	return sig, err
 }
 
 // Sign returns an ECDSA signature of keccak256(buf).
 func (s *Signer) Sign(buf []byte) ([]byte, error) {
-	return s.RawSign(crypto.Keccak256(buf))
+	sig, _, err := s.sign(buf, signOpts{
+		raw:       false,
+		compact:   false,
+		personal:  false,
+		withNonce: false,
+	})
+	return sig, err
 }
 
-// CompactSign returns s.Sign(buf) with the final byte, the y parity (always 0
-// or 1), carried in the highest bit of the s parameter, as per EIP-2098. Using
-// CompactSign instead of Sign reduces gas by removing a word from calldata, and
-// is compatible with OpenZeppelin's ECDSA.recover() helper.
-func (s *Signer) CompactSign(buf []byte) ([]byte, error) {
-	rsv, err := s.Sign(buf)
-	if err != nil {
-		return nil, err
-	}
-
+// CompactifySignature converts a signature with the final byte, the y parity
+// (always 0 or 1), carried in the highest bit of the s parameter, as per
+// EIP-2098. Using compact signatures reduces gas by removing a word from
+// calldata, and is compatible with OpenZeppelin's ECDSA.recover() helper.
+func CompactifySignature(rsv []byte) ([]byte, error) {
 	// Convert the 65-byte signature returned by Sign() into a 64-byte
 	// compressed version, as described in
 	// https://eips.ethereum.org/EIPS/eip-2098.
@@ -132,26 +139,20 @@ func (s *Signer) CompactSign(buf []byte) ([]byte, error) {
 	return rsv[:64], nil
 }
 
-// SignWithNonce generates a 32-byte nonce with crypto/rand and returns
-// s.CompactSign(append(buf, nonce)). This can be verified in Solidity
-// via ecrecover with a hash value of
-// keccak256(abi.encodePacked(buf,nonce)).
-func (s *Signer) SignWithNonce(buf []byte) ([]byte, [32]byte, error) {
+// AppendRandomNonce appends random 32 bytes to the buffer, commonly used in
+// signature nonces.
+func AppendRandomNonce(buf []byte) ([]byte, [32]byte, error) {
 	var nonce [32]byte
 	if n, err := rand.Read(nonce[:]); n != 32 || err != nil {
 		return nil, nonce, fmt.Errorf("read 32 random bytes: got %d bytes with err %v", n, err)
 	}
 
-	sig, err := s.CompactSign(append(buf, nonce[:]...))
-	if err != nil {
-		return nil, nonce, err
-	}
-	return sig, nonce, nil
+	return append(buf, nonce[:]...), nonce, nil
 }
 
-// toEthSignedMessageHash converts a given message to conform to the signed data
+// ToEthSignedMessageHash converts a given message to conform to the signed data
 // standard according to EIP-191.
-func toEthPersonalSignedMessage(message []byte) []byte {
+func ToEthPersonalSignedMessage(message []byte) []byte {
 	prefix := []byte(fmt.Sprintf("\x19Ethereum Signed Message:\n%d", len(message)))
 	return append(prefix, message...)
 }
@@ -159,22 +160,68 @@ func toEthPersonalSignedMessage(message []byte) []byte {
 // PersonalSign returns an EIP-191 conform personal ECDSA signature of buf
 // Convenience wrapper for s.CompactSign(toEthPersonalSignedMessage(buf))
 func (s *Signer) PersonalSign(buf []byte) ([]byte, error) {
-	return s.CompactSign(toEthPersonalSignedMessage(buf))
+	sig, _, err := s.sign(buf, signOpts{
+		raw:       false,
+		compact:   true,
+		personal:  true,
+		withNonce: false,
+	})
+	return sig, err
 }
 
 // PersonalSignWithNonce generates a 32-byte nonce with crypto/rand and returns
 // s.PersonalSign(append(buf, nonce)).
 func (s *Signer) PersonalSignWithNonce(buf []byte) ([]byte, [32]byte, error) {
+	sig, nonce, err := s.sign(buf, signOpts{
+		raw:       false,
+		compact:   true,
+		personal:  true,
+		withNonce: true,
+	})
+	return sig, *nonce, err
+
+}
+
+type signOpts struct {
+	raw, compact, personal, withNonce bool
+}
+
+// sign signs a given buffer depending on the chosen options:
+// withNonce = true, appends a nonce to the message
+// compact = true, returns a compactified version of the signature according to
+// EIP-2098.
+// personal = true, adds a prefix to the message to conform to the EIP-191
+// personal message standard.
+// raw = false, the message is hashed before signing
+func (s *Signer) sign(buf []byte, opts signOpts) ([]byte, *[32]byte, error) {
 	var nonce [32]byte
-	if n, err := rand.Read(nonce[:]); n != 32 || err != nil {
-		return nil, nonce, fmt.Errorf("read 32 random bytes: got %d bytes with err %v", n, err)
+	var err error
+
+	if opts.withNonce {
+		buf, nonce, err = AppendRandomNonce(buf)
 	}
 
-	sig, err := s.PersonalSign(append(buf, nonce[:]...))
-	if err != nil {
-		return nil, nonce, err
+	if opts.personal {
+		buf = ToEthPersonalSignedMessage(buf)
 	}
-	return sig, nonce, nil
+
+	if !opts.raw {
+		buf = crypto.Keccak256(buf)
+	}
+
+	sig, err := crypto.Sign(buf, s.key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if opts.compact {
+		sig, err = CompactifySignature(sig)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return sig, &nonce, nil
 }
 
 // SignAddress is a convenience wrapper for s.PersonalSign(addr.Bytes()).

--- a/tests/crypto/crypto_test.go
+++ b/tests/crypto/crypto_test.go
@@ -110,9 +110,9 @@ func TestSingleUseSignature(t *testing.T) {
 
 	for _, tt := range signatureTestCases() {
 		t.Run(tt.name, func(t *testing.T) {
-			sig, nonce, err := tt.signer.SignWithNonce(tt.signedData)
+			sig, nonce, err := tt.signer.PersonalSignWithNonce(tt.signedData)
 			if err != nil {
-				t.Fatalf("%T.SignWithNonce(%v) error %v", tt.signer, tt.signedData, err)
+				t.Fatalf("%T.PersonalSignWithNonce(%v) error %v", tt.signer, tt.signedData, err)
 			}
 
 			_, got := checker.NeedsSignature(sim.Acc(0), tt.sentData, nonce, sig)
@@ -137,9 +137,9 @@ func TestReusableSignature(t *testing.T) {
 
 	for _, tt := range signatureTestCases() {
 		t.Run(tt.name, func(t *testing.T) {
-			sig, err := tt.signer.CompactSign(tt.signedData)
+			sig, err := tt.signer.PersonalSign(tt.signedData)
 			if err != nil {
-				t.Fatalf("%T.CompactSign(%v) error %v", tt.signer, tt.signedData, err)
+				t.Fatalf("%T.PersonalSign(%v) error %v", tt.signer, tt.signedData, err)
 			}
 
 			for i := 0; i < 2; i++ {
@@ -165,9 +165,9 @@ func TestAddressSignature(t *testing.T) {
 		t.Helper()
 		addr := sim.Addr(party)
 
-		sig, err := signer.SignAddress(addr)
+		sig, err := signer.PersonalSignAddress(addr)
 		if err != nil {
-			t.Fatalf("%T.SignAddress(%v) error %v", signer, addr, err)
+			t.Fatalf("%T.PersonalSignAddress(%v) error %v", signer, addr, err)
 		}
 		return sig
 	}


### PR DESCRIPTION
# Motivation
Following the discussion in #3.
Switching to EIP-191 confrom messages in `SignatureChecker.sol` will make it more compatible with other libraries such as `ethers.js` (https://docs.ethers.io/v5/api/signer/#Signer-signMessage).

# Implementation Summary
- Add separate EIP-191 conform signing routines to `eth.Signer()` 
- Switch to EIP-191 conform messages in `SignatureChecker.sol`
