### PR TITLE
Revisit contract wide Wyvern proxy pre-approval.

### DIFF
--- a/contracts/erc721/ERC721CommonEnumerable.sol
+++ b/contracts/erc721/ERC721CommonEnumerable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2021 the ethier authors (github.com/divergencetech/ethier)
+// Copyright (c) 2022 the ethier authors (github.com/divergencetech/ethier)
 pragma solidity >=0.8.0 <0.9.0;
 
 import "./ERC721Common.sol";
@@ -26,7 +26,7 @@ contract ERC721CommonEnumerable is ERC721Common, ERC721Enumerable {
         public
         view
         virtual
-        override(ERC721, ERC721Common, IERC721)
+        override(ERC721Common, ERC721, IERC721)
         returns (bool)
     {
         return ERC721Common.isApprovedForAll(owner, operator);

--- a/contracts/erc721/ERC721CommonEnumerable.sol
+++ b/contracts/erc721/ERC721CommonEnumerable.sol
@@ -18,20 +18,6 @@ contract ERC721CommonEnumerable is ERC721Common, ERC721Enumerable {
         ERC721Common(name, symbol)
     {}
 
-    /**
-    // @notice Returns ERC721Common.isApprovedForAll() to guarantee use of OpenSea
-    // gas-free listing functionality.
-    // */
-    // function isApprovedForAll(address owner, address operator)
-    //     public
-    //     view
-    //     virtual
-    //     override(ERC721, ERC721Common)
-    //     returns (bool)
-    // {
-    //     return ERC721Common.isApprovedForAll(owner, operator);
-    // }
-
     /// @notice Overrides _beforeTokenTransfer as required by inheritance.
     function _beforeTokenTransfer(
         address from,

--- a/contracts/erc721/ERC721CommonEnumerable.sol
+++ b/contracts/erc721/ERC721CommonEnumerable.sol
@@ -19,18 +19,18 @@ contract ERC721CommonEnumerable is ERC721Common, ERC721Enumerable {
     {}
 
     /**
-    @notice Returns ERC721Common.isApprovedForAll() to guarantee use of OpenSea
-    gas-free listing functionality.
-    */
-    function isApprovedForAll(address owner, address operator)
-        public
-        view
-        virtual
-        override(ERC721, ERC721Common, IERC721)
-        returns (bool)
-    {
-        return ERC721Common.isApprovedForAll(owner, operator);
-    }
+    // @notice Returns ERC721Common.isApprovedForAll() to guarantee use of OpenSea
+    // gas-free listing functionality.
+    // */
+    // function isApprovedForAll(address owner, address operator)
+    //     public
+    //     view
+    //     virtual
+    //     override(ERC721, ERC721Common)
+    //     returns (bool)
+    // {
+    //     return ERC721Common.isApprovedForAll(owner, operator);
+    // }
 
     /// @notice Overrides _beforeTokenTransfer as required by inheritance.
     function _beforeTokenTransfer(
@@ -50,5 +50,23 @@ contract ERC721CommonEnumerable is ERC721Common, ERC721Enumerable {
         returns (bool)
     {
         return super.supportsInterface(interfaceId);
+    }
+
+    function setApprovalForAll(address operator, bool approved)
+        public
+        virtual
+        override(ERC721Common, ERC721)
+    {
+        ERC721Common.setApprovalForAll(operator, approved);
+    }
+
+    function isApprovedForAll(address owner, address operator)
+        public
+        view
+        virtual
+        override(ERC721Common, ERC721)
+        returns (bool)
+    {
+        return ERC721Common.isApprovedForAll(owner, operator);
     }
 }

--- a/contracts/erc721/ERC721CommonEnumerable.sol
+++ b/contracts/erc721/ERC721CommonEnumerable.sol
@@ -18,6 +18,30 @@ contract ERC721CommonEnumerable is ERC721Common, ERC721Enumerable {
         ERC721Common(name, symbol)
     {}
 
+    /**
+    @notice Returns ERC721Common.isApprovedForAll() to guarantee use of OpenSea
+    gas-free listing functionality.
+    */
+    function isApprovedForAll(address owner, address operator)
+        public
+        view
+        virtual
+        override(ERC721, ERC721Common, IERC721)
+        returns (bool)
+    {
+        return ERC721Common.isApprovedForAll(owner, operator);
+    }
+
+    /// @dev Calls ERC721Common.setApprovalForAll to manage pre-approvals
+    /// related to OpenSea's gas-free listing functionality.
+    function setApprovalForAll(address operator, bool approved)
+        public
+        virtual
+        override(ERC721Common, ERC721, IERC721)
+    {
+        ERC721Common.setApprovalForAll(operator, approved);
+    }
+
     /// @notice Overrides _beforeTokenTransfer as required by inheritance.
     function _beforeTokenTransfer(
         address from,
@@ -36,23 +60,5 @@ contract ERC721CommonEnumerable is ERC721Common, ERC721Enumerable {
         returns (bool)
     {
         return super.supportsInterface(interfaceId);
-    }
-
-    function setApprovalForAll(address operator, bool approved)
-        public
-        virtual
-        override(ERC721Common, ERC721)
-    {
-        ERC721Common.setApprovalForAll(operator, approved);
-    }
-
-    function isApprovedForAll(address owner, address operator)
-        public
-        view
-        virtual
-        override(ERC721Common, ERC721)
-        returns (bool)
-    {
-        return ERC721Common.isApprovedForAll(owner, operator);
     }
 }

--- a/contracts/erc721/ERC721PreApproval.sol
+++ b/contracts/erc721/ERC721PreApproval.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021 the ethier authors (github.com/divergencetech/ethier)
+pragma solidity >=0.8.0 <0.9.0;
+
+import "../thirdparty/opensea/OpenSeaGasFreeListing.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+/// @notice Pre-approval of OpenSea proxies for gas-less listing
+/// @dev This wrapper allows users to revoke the pre-approval of their
+/// associated proxy and emits the corresponding events. This is necessary for
+/// external tools to index approvals correctly and inform the user.
+/// @dev The pre-approval is triggered on a per-wallet basis during the first
+/// transfer transactions. It will only be enabled for wallets with an existing
+/// proxy. Not having a proxy incurs a gas overhead.
+/// @dev This wrapper optimizes for the following scenario:
+/// - The majority of users already have a wyvern proxy
+/// - Most of them want to transfer tokens via wyvern exchanges
+abstract contract ERC721PreApproval is ERC721 {
+    /// @dev It is important that Active remains at first position, since this
+    /// is the scenario that we are trying to optimize for.
+    enum State {
+        Active,
+        Inactive
+    }
+
+    /// @notice The state of the pre-approval for a given address
+    mapping(address => State) private state;
+
+    /// @dev Returns true if either standard `isApprovedForAll()` or if the
+    /// `operator` is the OpenSea proxy for the `owner` provided the
+    /// pre-approval is active.
+    function isApprovedForAll(address owner, address operator)
+        public
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        if (super.isApprovedForAll(owner, operator)) {
+            return true;
+        }
+
+        if (state[owner] == State.Active) {
+            return OpenSeaGasFreeListing.isApprovedForAll(owner, operator);
+        }
+
+        return false;
+    }
+
+    /// @dev Uses the standard `setApprovalForAll` or toggles the pre-approval
+    /// state if `operator` is the OpenSea proxy for the sender.
+    function setApprovalForAll(address operator, bool approved)
+        public
+        virtual
+        override
+    {
+        address owner = _msgSender();
+        if (operator == OpenSeaGasFreeListing.proxyFor(owner)) {
+            state[owner] = approved ? State.Active : State.Inactive;
+            emit ApprovalForAll(owner, operator, approved);
+        } else {
+            super._setApprovalForAll(owner, operator, approved);
+        }
+    }
+
+    /// @dev Checks if the receiver has an existing proxy. If not, the
+    /// pre-approval is disabled.
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override {
+        super._beforeTokenTransfer(from, to, tokenId);
+
+        // Exclude burns
+        if (to != address(0) && state[to] == State.Active) {
+            address operator = OpenSeaGasFreeListing.proxyFor(to);
+
+            // Disable if `to` has no proxy
+            if (operator == address(0)) {
+                state[to] = State.Inactive;
+                return;
+            }
+
+            // Avoid emitting unnecessary events.
+            if (balanceOf(to) == 0) {
+                emit ApprovalForAll(to, operator, true);
+            }
+        }
+    }
+}

--- a/tests/erc721/TestableERC721CommonEnumerable.sol
+++ b/tests/erc721/TestableERC721CommonEnumerable.sol
@@ -16,6 +16,10 @@ contract TestableERC721CommonEnumerable is
         ERC721._safeMint(msg.sender, tokenId);
     }
 
+    function burn(uint256 tokenId) public {
+        ERC721._burn(tokenId);
+    }
+
     /// @dev For testing the tokenExists() modifier.
     function mustExist(uint256 tokenId) public view tokenExists(tokenId) {}
 

--- a/tests/erc721/erc721_test.go
+++ b/tests/erc721/erc721_test.go
@@ -322,6 +322,7 @@ func TestOpenSeaProxyPreApprovalOptInOut(t *testing.T) {
 		mints                bool
 		createProxyAfterMint bool
 		hasProxyAfterMint    bool
+		doSetApproved        bool
 		setApprovedTo        bool
 		wantApproved         bool
 		wantEvents           []*ERC721ApprovalForAll
@@ -331,6 +332,7 @@ func TestOpenSeaProxyPreApprovalOptInOut(t *testing.T) {
 			hasProxyBeforeMint:   true,
 			mints:                true,
 			createProxyAfterMint: false,
+			doSetApproved:        true,
 			setApprovedTo:        true,
 			wantApproved:         true,
 			wantEvents: []*ERC721ApprovalForAll{
@@ -351,6 +353,7 @@ func TestOpenSeaProxyPreApprovalOptInOut(t *testing.T) {
 			hasProxyBeforeMint:   true,
 			mints:                true,
 			createProxyAfterMint: false,
+			doSetApproved:        true,
 			setApprovedTo:        false,
 			wantApproved:         false,
 			wantEvents: []*ERC721ApprovalForAll{
@@ -371,6 +374,7 @@ func TestOpenSeaProxyPreApprovalOptInOut(t *testing.T) {
 			hasProxyBeforeMint:   true,
 			mints:                false,
 			createProxyAfterMint: false,
+			doSetApproved:        true,
 			setApprovedTo:        true,
 			wantApproved:         true,
 			wantEvents: []*ERC721ApprovalForAll{
@@ -386,6 +390,7 @@ func TestOpenSeaProxyPreApprovalOptInOut(t *testing.T) {
 			hasProxyBeforeMint:   true,
 			mints:                false,
 			createProxyAfterMint: false,
+			doSetApproved:        true,
 			setApprovedTo:        false,
 			wantApproved:         false,
 			wantEvents: []*ERC721ApprovalForAll{
@@ -401,6 +406,7 @@ func TestOpenSeaProxyPreApprovalOptInOut(t *testing.T) {
 			hasProxyBeforeMint:   false,
 			mints:                true,
 			createProxyAfterMint: false,
+			doSetApproved:        true,
 			setApprovedTo:        true,
 			wantApproved:         true,
 			wantEvents: []*ERC721ApprovalForAll{
@@ -416,6 +422,7 @@ func TestOpenSeaProxyPreApprovalOptInOut(t *testing.T) {
 			hasProxyBeforeMint:   false,
 			mints:                true,
 			createProxyAfterMint: false,
+			doSetApproved:        true,
 			setApprovedTo:        false,
 			wantApproved:         false,
 			wantEvents: []*ERC721ApprovalForAll{
@@ -431,6 +438,7 @@ func TestOpenSeaProxyPreApprovalOptInOut(t *testing.T) {
 			hasProxyBeforeMint:   false,
 			mints:                false,
 			createProxyAfterMint: false,
+			doSetApproved:        true,
 			setApprovedTo:        true,
 			wantApproved:         true,
 			wantEvents: []*ERC721ApprovalForAll{
@@ -446,6 +454,7 @@ func TestOpenSeaProxyPreApprovalOptInOut(t *testing.T) {
 			hasProxyBeforeMint:   false,
 			mints:                false,
 			createProxyAfterMint: false,
+			doSetApproved:        true,
 			setApprovedTo:        false,
 			wantApproved:         false,
 			wantEvents: []*ERC721ApprovalForAll{
@@ -461,6 +470,7 @@ func TestOpenSeaProxyPreApprovalOptInOut(t *testing.T) {
 			hasProxyBeforeMint:   false,
 			mints:                true,
 			createProxyAfterMint: true,
+			doSetApproved:        true,
 			setApprovedTo:        true,
 			wantApproved:         true,
 			wantEvents: []*ERC721ApprovalForAll{
@@ -476,6 +486,7 @@ func TestOpenSeaProxyPreApprovalOptInOut(t *testing.T) {
 			hasProxyBeforeMint:   false,
 			mints:                true,
 			createProxyAfterMint: true,
+			doSetApproved:        true,
 			setApprovedTo:        false,
 			wantApproved:         false,
 			wantEvents: []*ERC721ApprovalForAll{
@@ -485,6 +496,15 @@ func TestOpenSeaProxyPreApprovalOptInOut(t *testing.T) {
 					Approved: false,
 				},
 			},
+		},
+		{
+			name:                 "creating proxy after minting without proxy",
+			hasProxyBeforeMint:   false,
+			mints:                true,
+			createProxyAfterMint: true,
+			doSetApproved:        false,
+			wantApproved:         false,
+			wantEvents:           nil,
 		},
 	}
 
@@ -505,9 +525,11 @@ func TestOpenSeaProxyPreApprovalOptInOut(t *testing.T) {
 				openseatest.SetProxyTB(t, sim, sim.Addr(tokenReceiver), sim.Addr(proxy))
 			}
 
-			sim.Must(t, "%T.setApprovalForAll(proxy,%v)", nft, tt.setApprovedTo)(
-				nft.SetApprovalForAll(sim.Acc(tokenReceiver), sim.Addr(proxy), tt.setApprovedTo),
-			)
+			if tt.doSetApproved {
+				sim.Must(t, "%T.setApprovalForAll(proxy,%v)", nft, tt.setApprovedTo)(
+					nft.SetApprovalForAll(sim.Acc(tokenReceiver), sim.Addr(proxy), tt.setApprovedTo),
+				)
+			}
 
 			got, err := nft.IsApprovedForAll(nil, sim.Addr(tokenReceiver), sim.Addr(proxy))
 			if err != nil || got != tt.wantApproved {


### PR DESCRIPTION
# Motivation
Wyvern proxies are currently pre-approved by hard-coding them into the ERC721 base contract, which means that their access cannot be revoked by users. Since the corresponding `ApprovalForAll` events are not emitted, most external indexing tools will not be able to correctly recognized the approval state for a given user. This can lead to situations where users have wrong information on the security of their tokens and cannot change it if desired.

# Implementation
Introducing a new wrapper class for pre-approvals that

- allows opt-outs on a per-wallet basis
- emits events during transfers