### PR TITLE
Add ERC2981 to ERC721ACommon

### DIFF
--- a/contracts/erc721/ERC721ACommon.sol
+++ b/contracts/erc721/ERC721ACommon.sol
@@ -17,9 +17,9 @@ contract ERC721ACommon is ERC721APreApproval, OwnerPausable, ERC2981 {
         string memory name,
         string memory symbol,
         address payable royaltyReciever,
-        uint96 royaltyPermyriad
+        uint96 royaltyBasisPoints
     ) ERC721A(name, symbol) {
-        _setDefaultRoyalty(royaltyReciever, royaltyPermyriad);
+        _setDefaultRoyalty(royaltyReciever, royaltyBasisPoints);
     }
 
     /// @notice Requires that the token exists.
@@ -60,12 +60,12 @@ contract ERC721ACommon is ERC721APreApproval, OwnerPausable, ERC2981 {
             ERC2981.supportsInterface(interfaceId);
     }
 
-    /// @notice Sets the royalty receiver and percentage (in units of permyriad
-    /// = 0.01%).
-    function setDefaultRoyalty(address receiver, uint96 permyriad)
+    /// @notice Sets the royalty receiver and percentage (in units of basis
+    /// points = 0.01%).
+    function setDefaultRoyalty(address receiver, uint96 basisPoints)
         external
         onlyOwner
     {
-        _setDefaultRoyalty(receiver, permyriad);
+        _setDefaultRoyalty(receiver, basisPoints);
     }
 }

--- a/contracts/erc721/ERC721ACommon.sol
+++ b/contracts/erc721/ERC721ACommon.sol
@@ -60,12 +60,12 @@ contract ERC721ACommon is ERC721APreApproval, OwnerPausable, ERC2981 {
             ERC2981.supportsInterface(interfaceId);
     }
 
-    /// @notice Sets the royalty receiver and percentage (in units of permyriads
+    /// @notice Sets the royalty receiver and percentage (in units of permyriad
     /// = 0.01%).
-    function setDefaultRoyalty(address receiver, uint96 permyriads)
+    function setDefaultRoyalty(address receiver, uint96 permyriad)
         external
         onlyOwner
     {
-        _setDefaultRoyalty(receiver, permyriads);
+        _setDefaultRoyalty(receiver, permyriad);
     }
 }

--- a/contracts/erc721/ERC721ACommon.sol
+++ b/contracts/erc721/ERC721ACommon.sol
@@ -10,15 +10,16 @@ import "@openzeppelin/contracts/token/common/ERC2981.sol";
 @notice An ERC721A contract with common functionality:
  - OpenSea gas-free listings
  - Pausable with toggling functions exposed to Owner only
+ - ERC2981 royalties
  */
 contract ERC721ACommon is ERC721APreApproval, OwnerPausable, ERC2981 {
     constructor(
         string memory name,
         string memory symbol,
         address payable royaltyReciever,
-        uint96 royaltyPermille
+        uint96 royaltyPermyriad
     ) ERC721A(name, symbol) {
-        _setDefaultRoyalty(royaltyReciever, royaltyPermille);
+        _setDefaultRoyalty(royaltyReciever, royaltyPermyriad);
     }
 
     /// @notice Requires that the token exists.
@@ -59,15 +60,12 @@ contract ERC721ACommon is ERC721APreApproval, OwnerPausable, ERC2981 {
             ERC2981.supportsInterface(interfaceId);
     }
 
-    /// @notice Sets the royalty receiver and percentage (in units of 0.01%).
-    function setDefaultRoyalty(address receiver, uint96 permille)
+    /// @notice Sets the royalty receiver and percentage (in units of permyriads
+    /// = 0.01%).
+    function setDefaultRoyalty(address receiver, uint96 permyriads)
         external
         onlyOwner
     {
-        _setDefaultRoyalty(receiver, permille);
-    }
-
-    function _feeDenominator() internal pure virtual override returns (uint96) {
-        return 1000;
+        _setDefaultRoyalty(receiver, permyriads);
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@divergencetech/ethier",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "Golang and Solidity SDK to make Ethereum development ethier",
   "main": "\"\"",
   "scripts": {

--- a/tests/erc721/TestableERC721ACommon.sol
+++ b/tests/erc721/TestableERC721ACommon.sol
@@ -8,7 +8,10 @@ import "../../contracts/erc721/BaseTokenURI.sol";
 /// @notice Exposes a functions modified with the modifiers under test.
 contract TestableERC721ACommon is ERC721ACommon, BaseTokenURI {
     // solhint-disable-next-line no-empty-blocks
-    constructor() ERC721ACommon("Token", "JRR") BaseTokenURI("") {}
+    constructor(address payable royaltyReciever)
+        ERC721ACommon("Token", "JRR", royaltyReciever, 750)
+        BaseTokenURI("")
+    {}
 
     function mint() public {
         mintN(1);

--- a/tests/erc721/TestableERC721ACommon.sol
+++ b/tests/erc721/TestableERC721ACommon.sol
@@ -8,8 +8,8 @@ import "../../contracts/erc721/BaseTokenURI.sol";
 /// @notice Exposes a functions modified with the modifiers under test.
 contract TestableERC721ACommon is ERC721ACommon, BaseTokenURI {
     // solhint-disable-next-line no-empty-blocks
-    constructor(address payable royaltyReciever)
-        ERC721ACommon("Token", "JRR", royaltyReciever, 750)
+    constructor(address payable royaltyReciever, uint96 royaltyBasisPoints)
+        ERC721ACommon("Token", "JRR", royaltyReciever, royaltyBasisPoints)
         BaseTokenURI("")
     {} // solhint-disable-line no-empty-blocks
 

--- a/tests/erc721/TestableERC721ACommon.sol
+++ b/tests/erc721/TestableERC721ACommon.sol
@@ -11,7 +11,7 @@ contract TestableERC721ACommon is ERC721ACommon, BaseTokenURI {
     constructor(address payable royaltyReciever)
         ERC721ACommon("Token", "JRR", royaltyReciever, 750)
         BaseTokenURI("")
-    {}
+    {} // solhint-disable-line no-empty-blocks
 
     function mint() public {
         mintN(1);

--- a/tests/erc721/erc721_test.go
+++ b/tests/erc721/erc721_test.go
@@ -583,7 +583,10 @@ func TestRoyalties(t *testing.T) {
 		if err != nil || big.NewInt(wantAmount).Cmp(amount) != 0 || wantReceiver != receiver {
 			t.Errorf("RoyaltyInfo(0, %d) got (%s, %d), err = %v; want (%s, %d), nil err", tt.salesPrice, receiver, amount, err, wantReceiver, wantAmount)
 		}
+	}
 
+	if diff := revert.OnlyOwner.Diff(nft.SetDefaultRoyalty(sim.Acc(vandal), sim.Addr(vandal), big.NewInt(1000))); diff != "" {
+		t.Errorf("SetDefaultRoyalty([as vandal]) %s", diff)
 	}
 }
 

--- a/tests/erc721/erc721_test.go
+++ b/tests/erc721/erc721_test.go
@@ -549,32 +549,32 @@ func TestRoyalties(t *testing.T) {
 	sim, nft, _ := deploy(t)
 
 	tests := []struct {
-		setConfig   bool
-		newReceiver common.Address
-		newPermille int64
-		salesPrice  int64
+		setConfig    bool
+		newReceiver  common.Address
+		newPermyriad int64
+		salesPrice   int64
 	}{
 		{
 			salesPrice: 200000,
 		},
 		{
-			setConfig:   true,
-			newReceiver: sim.Addr(deployer),
-			newPermille: 300,
-			salesPrice:  500000,
+			setConfig:    true,
+			newReceiver:  sim.Addr(deployer),
+			newPermyriad: 300,
+			salesPrice:   500000,
 		},
 	}
 
 	for _, tt := range tests {
 		if tt.setConfig {
-			nft.SetDefaultRoyalty(sim.Acc(deployer), tt.newReceiver, big.NewInt(tt.newPermille))
+			nft.SetDefaultRoyalty(sim.Acc(deployer), tt.newReceiver, big.NewInt(tt.newPermyriad))
 		}
 
-		wantAmount := tt.salesPrice / 1000 * 750
+		wantAmount := tt.salesPrice / 1000 * 75
 		wantReceiver := sim.Addr(royaltyReceiver)
 
 		if tt.setConfig {
-			wantAmount = tt.salesPrice / 1000 * tt.newPermille
+			wantAmount = tt.salesPrice / 10000 * tt.newPermyriad
 			wantReceiver = tt.newReceiver
 		}
 


### PR DESCRIPTION
This adds the ERC2981 royalty standard to our `ERC721ACommon` base contract.
The royalty shares are denoted in terms of permyriads (0.01%, OZ default).