### PR TITLE
Deprecate compact signatures

### DIFF
--- a/eth/signer.go
+++ b/eth/signer.go
@@ -170,7 +170,11 @@ func WithPersonalMessagePrefix(message []byte) []byte {
 }
 
 type signOpts struct {
-	raw, compact, personal, withNonce bool
+	raw bool
+	// Deprecated: Compact signatures are now longer supported by ethier contracts.
+	compact   bool
+	personal  bool
+	withNonce bool
 }
 
 // sign signs a given buffer depending on the chosen options:

--- a/eth/signer.go
+++ b/eth/signer.go
@@ -134,6 +134,8 @@ func (s *Signer) Address() common.Address {
 // (always 0 or 1), carried in the highest bit of the s parameter, as per
 // EIP-2098. Using compact signatures reduces gas by removing a word from
 // calldata, and is compatible with OpenZeppelin's ECDSA.recover() helper.
+//
+// Deprecated: Compact signatures are now longer supported by ethier contracts.
 func CompactSignature(rsv []byte) ([]byte, error) {
 	// Convert the 65-byte signature returned by Sign() into a 64-byte
 	// compressed version, as described in
@@ -173,11 +175,12 @@ type signOpts struct {
 
 // sign signs a given buffer depending on the chosen options:
 // withNonce = true, appends a nonce to the message
-// compact = true, returns a compactified version of the signature according to
-// EIP-2098.
 // personal = true, adds a prefix to the message to conform to the EIP-191
 // personal message standard.
 // raw = false, the message is hashed before signing
+// compact = true, returns a compactified version of the signature according to
+// EIP-2098. Deprecated: Compact signatures are now longer supported by ethier
+// contracts.
 func (s *Signer) sign(buf []byte, opts signOpts) ([]byte, *[32]byte, error) {
 	var nonce *[32]byte
 	var err error
@@ -245,7 +248,7 @@ func (s *Signer) Sign(buf []byte) ([]byte, error) {
 func (s *Signer) PersonalSign(buf []byte) ([]byte, error) {
 	sig, _, err := s.sign(buf, signOpts{
 		raw:       false,
-		compact:   true,
+		compact:   false,
 		personal:  true,
 		withNonce: false,
 	})
@@ -257,7 +260,7 @@ func (s *Signer) PersonalSign(buf []byte) ([]byte, error) {
 func (s *Signer) PersonalSignWithNonce(buf []byte) ([]byte, [32]byte, error) {
 	sig, nonce, err := s.sign(buf, signOpts{
 		raw:       false,
-		compact:   true,
+		compact:   false,
 		personal:  true,
 		withNonce: true,
 	})

--- a/eth/signer.go
+++ b/eth/signer.go
@@ -208,6 +208,8 @@ func (s *Signer) sign(buf []byte, opts signOpts) ([]byte, *[32]byte, error) {
 	}
 
 	if !opts.compact {
+		// yParities are shifted by 27 for Ethereum signatures by convention.
+		sig[64] += 27
 		return sig, nonce, nil
 	}
 

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "license": "MIT",
   "dependencies": {
     "@chainlink/contracts": "^0.3.0",
-    "@openzeppelin/contracts": "4.7.0",
-    "@openzeppelin/contracts-upgradeable": "4.7.0",
+    "@openzeppelin/contracts": "4.7.3",
+    "@openzeppelin/contracts-upgradeable": "4.7.3",
     "erc721a": "4.2.2"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@divergencetech/ethier",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Golang and Solidity SDK to make Ethereum development ethier",
   "main": "\"\"",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,15 +28,15 @@
   resolved "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.3.0.tgz"
   integrity sha512-Pxu5qMTa0gc28Sxf9hyBkvwhPMn3HD62cGXy54RkL9PcabOHlUsk1i3BoFf3rwFr7T30N/obYn4de3ZrG12PDA==
 
-"@openzeppelin/contracts-upgradeable@4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.0.tgz#6437261286879d353f6de7bf3ac8216bef8a486d"
-  integrity sha512-wO3PyoAaAV/rA77cK8H4c3SbO98QylTjfiFxyvURUZKTFLV180rnAvna1x7/Nxvt0Gqv+jt1sXKC7ygxsq8iCw==
+"@openzeppelin/contracts-upgradeable@4.7.3":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.3.tgz#f1d606e2827d409053f3e908ba4eb8adb1dd6995"
+  integrity sha512-+wuegAMaLcZnLCJIvrVUDzA9z/Wp93f0Dla/4jJvIhijRrPabjQbZe6fWiECLaJyfn5ci9fqf9vTw3xpQOad2A==
 
-"@openzeppelin/contracts@4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.0.tgz#3092d70ea60e3d1835466266b1d68ad47035a2d5"
-  integrity sha512-52Qb+A1DdOss8QvJrijYYPSf32GUg2pGaG/yCxtaA3cu4jduouTdg4XZSMLW9op54m1jH7J8hoajhHKOPsoJFw==
+"@openzeppelin/contracts@4.7.3":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.3.tgz#939534757a81f8d69cc854c7692805684ff3111e"
+  integrity sha512-dGRS0agJzu8ybo44pCIf3xBaPQN/65AIXNgK8+4gzKd5kbvlqyxryUYVLJv7fK98Seyd2hDZzVEHSWAh0Bt1Yw==
 
 "@solidity-parser/parser@^0.14.0", "@solidity-parser/parser@^0.14.1":
   version "0.14.1"


### PR DESCRIPTION
- Mark relevant functions as deprecated
- Change signing defaults
- Fix bug in the parity of standard signatures

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/divergencetech/ethier/56)
<!-- Reviewable:end -->
