### PR TITLE
Replace Rinkeby PaymentSplitterFactory with a Goerli deployment

### DIFF
--- a/contracts/factories/PaymentSplitterDeployer.sol
+++ b/contracts/factories/PaymentSplitterDeployer.sol
@@ -25,9 +25,9 @@ library PaymentSplitterDeployer {
                 // mainnet
                 factory := 0xf034d6a4b1a64f0e6038632d87746ca24b79d325
             }
-            case 4 {
-                // Rinkeby
-                factory := 0x633dc916D9f59cf4aA117dE2Bb8edF7752270EC0
+            case 5 {
+                // Görli
+                factory := 0x7F4Ae949da2eD37E0a4b37e0b15B22Ad5c94DE65
             }
             case 1337 {
                 // The geth SimulatedBackend iff used with the ethier

--- a/contracts/factories/README.md
+++ b/contracts/factories/README.md
@@ -60,4 +60,4 @@ contract LookMaNoAddress {
 
 * `PaymentSplitter`
   * [Mainnet](https://etherscan.io/address/0xf034d6a4b1a64f0e6038632d87746ca24b79d325#code)
-  * [Rinkeby](https://rinkeby.etherscan.io/address/0x633dc916D9f59cf4aA117dE2Bb8edF7752270EC0#code)
+  * [Goerli](https://goerli.etherscan.io/address/0x7F4Ae949da2eD37E0a4b37e0b15B22Ad5c94DE65#code)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@divergencetech/ethier",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Golang and Solidity SDK to make Ethereum development ethier",
   "main": "\"\"",
   "scripts": {


### PR DESCRIPTION
- Removing the Rinkbey PaymentSplitterFactory address from the library since the network is now deprecated
- Adding a Goerli deployment

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/divergencetech/ethier/61)
<!-- Reviewable:end -->
