### PR TITLE
Support for multiple metadata/image endpoints on `erc721.Server`.

### DIFF
--- a/erc721/server_test.go
+++ b/erc721/server_test.go
@@ -35,7 +35,7 @@ func deploy(t *testing.T, totalSupply int64) Interface {
 
 // start starts a new http server with requests handled by srv.Handler(), and
 // returns the base URL of the started server.
-func start(t *testing.T, srv *MetadataServer) string {
+func start(t *testing.T, srv *Server) string {
 	handler, err := srv.Handler()
 	if err != nil {
 		t.Fatalf("%T{%+v}.Handler() error %v", srv, srv, err)
@@ -120,7 +120,7 @@ func TestMetadataServer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 
-			srv := &MetadataServer{
+			srv := &Server{
 				BaseURL:     nil, // will be set to the test-server URL by start()
 				TokenIDBase: 16,
 				Contract:    deploy(t, totalSupply),
@@ -241,7 +241,7 @@ func TestMetadataServer(t *testing.T) {
 }
 
 func TestMultipleMetadataEndpoints(t *testing.T) {
-	srv := &MetadataServer{
+	srv := &Server{
 		Metadata: []MetadataEndpoint{
 			{
 				Path: "/default/:tokenId",


### PR DESCRIPTION
`erc721.Server` was named `erc721.MetadataServer` before this PR.

The `erc721.Server.MetdataPath` and `Metadata` fields have been combined into an `erc721.MetadataEndpoint` type, of which the server accepts a slice. Similarly for images.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/divergencetech/ethier/71)
<!-- Reviewable:end -->
