### PR TITLE
NextShuffler rework

### DIFF
--- a/contracts/random/NextShuffler.sol
+++ b/contracts/random/NextShuffler.sol
@@ -71,6 +71,8 @@ library NextShuffler {
      * memory.
      * @dev NB: See the `dev` documentation of this contract re security (or
      * lack thereof) of deterministic shuffling.
+     * @param rand Uniformly distributed random number in
+     * [0, state.numToShuffle - state.shuffled)
      */
     function next(State storage state, uint256 rand)
         internal
@@ -86,9 +88,9 @@ library NextShuffler {
 
         uint256 chosen = _get(state, rand);
 
-        // Even though afull swap of the elements in the list is not needed for
+        // Even though a full swap of the elements in the list is not needed for
         // the algoritm to work, we do it anyway because it allows us to restart
-        // the shuffling at any given point.
+        // the shuffling.
         _set(state, rand, _get(state, shuffled));
         _set(state, shuffled, chosen);
 
@@ -103,13 +105,16 @@ library NextShuffler {
      * memory together with the random number that was used for the drawing.
      * @dev NB: See the `dev` documentation of this contract re security (or
      * lack thereof) of deterministic shuffling.
+     * @dev This is intended to be used if the random number drawn from `src`
+     * that was used for shuffling needs to be reused for something else, e.g.
+     * to thoroughly test the algorithm.
      */
-    function nextWithRand(State storage state, PRNG.Source src)
+    function nextAndRand(State storage state, PRNG.Source src)
         internal
-        returns (uint256, uint256)
+        returns (uint256 choice, uint256 rand)
     {
-        uint256 rand = src.readLessThan(state.numToShuffle - state.shuffled);
-        return (next(state, rand), rand);
+        src.readLessThan(state.numToShuffle - state.shuffled);
+        choice = next(state, rand);
     }
 
     /**
@@ -122,7 +127,7 @@ library NextShuffler {
         internal
         returns (uint256)
     {
-        (uint256 choice, ) = nextWithRand(state, src);
+        (uint256 choice, ) = nextAndRand(state, src);
         return choice;
     }
 

--- a/contracts/random/NextShuffler.sol
+++ b/contracts/random/NextShuffler.sol
@@ -5,77 +5,153 @@ pragma solidity >=0.8.9 <0.9.0;
 import "./PRNG.sol";
 
 /**
-@notice Returns the next value in a shuffled list [0,n), amortising the shuffle
-across all calls to _next(). Can be used for randomly allocating a set of tokens
-but the caveats in `dev` docs MUST be noted.
-@dev Although the final shuffle is uniformly random, it is entirely
-deterministic if the seed to the PRNG.Source is known. This MUST NOT be used for
-applications that require secure (i.e. can't be manipulated) allocation unless
-parties who stand to gain from malicious use have no control over nor knowledge
-of the seed at the time that their transaction results in a call to _next().
+ * @notice Returns the next value in a shuffled list [0,n), amortising the
+ * shuffle across all calls to _next(). Can be used for randomly allocating a
+ * set of tokens but the caveats in `dev` docs MUST be noted.
+ * @dev Although the final shuffle is uniformly random, it is entirely
+ * deterministic if the seed to the PRNG.Source is known. This MUST NOT be used
+ * for applications that require secure (i.e. can't be manipulated) allocation
+ * unless parties who stand to gain from malicious use have no control over nor
+ * knowledge of the seed at the time that their transaction results in a call to
+ * next().
  */
-contract NextShuffler {
+library NextShuffler {
     using PRNG for PRNG.Source;
 
-    /// @notice Total number of elements to shuffle.
-    uint256 public immutable numToShuffle;
-
-    /// @param numToShuffle_ Total number of elements to shuffle.
-    constructor(uint256 numToShuffle_) {
-        numToShuffle = numToShuffle_;
+    struct State {
+        // Number of items already shuffled.
+        // This is the equivalent of `i` in the Wikipedia description of the
+        // Fisher–Yates algorithm.
+        uint256 shuffled;
+        // The number of items that will be shuffled.
+        uint256 numToShuffle;
+        // A sparse representation of the shuffled list [0,n). List items that
+        // have been shuffled are stored with their original index as the key
+        // and their new index + 1 as their value. Note that mappings with
+        // numerical values return 0 for non-existent keys so we MUST increment
+        // the new index to differentiate between a default value and a new
+        // index of 0. See _get() and _set().
+        mapping(uint256 => uint256) permutation;
     }
 
     /**
-    @dev Number of items already shuffled; i.e. number of historical calls to
-    _next(). This is the equivalent of `i` in the Wikipedia description of the
-    Fisher–Yates algorithm.
+     * @notice Initialises a shuffler at a given location in storage.
      */
-    uint256 private shuffled;
+    function init(State storage state, uint256 numToShuffle) internal {
+        state.numToShuffle = numToShuffle;
+    }
 
     /**
-    @dev A sparse representation of the shuffled list [0,n). List items that
-    have been shuffled are stored with their original index as the key and their
-    new index + 1 as their value. Note that mappings with numerical values
-    return 0 for non-existent keys so we MUST increment the new index to
-    differentiate between a default value and a new index of 0. See _get() and
-    _set().
+     * @notice Returns the current value stored in list index `i`, accounting
+     * for all historical shuffling.
      */
-    mapping(uint256 => uint256) private _permutation;
-
-    /**
-    @notice Returns the current value stored in list index `i`, accounting for
-    all historical shuffling.
-     */
-    function _get(uint256 i) private view returns (uint256) {
-        uint256 val = _permutation[i];
+    function _get(State storage state, uint256 i)
+        private
+        view
+        returns (uint256)
+    {
+        uint256 val = state.permutation[i];
         return val == 0 ? i : val - 1;
     }
 
     /**
-    @notice Sets the list index `i` to `val`, equivalent `arr[i] = val` in a
-    standard Fisher–Yates shuffle.
+     * @notice Sets the list index `i` to `val`, equivalent `arr[i] = val` in a
+     * standard Fisher–Yates shuffle.
      */
-    function _set(uint256 i, uint256 val) private {
-        _permutation[i] = i == val ? 0 : val + 1;
+    function _set(
+        State storage state,
+        uint256 i,
+        uint256 val
+    ) private {
+        state.permutation[i] = i == val ? 0 : val + 1;
     }
 
-    /// @notice Emited on each call to _next() to allow for thorough testing.
-    event ShuffledWith(uint256 current, uint256 with);
+    /**
+     * @notice Returns the next value in the shuffle list in O(1) time and
+     * memory.
+     * @dev NB: See the `dev` documentation of this contract re security (or
+     * lack thereof) of deterministic shuffling.
+     */
+    function next(State storage state, uint256 rand)
+        internal
+        returns (uint256)
+    {
+        uint256 shuffled = state.shuffled;
+        require(!finished(state), "NextShuffler: finished");
+
+        unchecked {
+            // Cannot overflow if rand is supplied as specified.
+            rand += shuffled;
+        }
+
+        uint256 chosen = _get(state, rand);
+
+        // Even though afull swap of the elements in the list is not needed for
+        // the algoritm to work, we do it anyway because it allows us to restart
+        // the shuffling at any given point.
+        _set(state, rand, _get(state, shuffled));
+        _set(state, shuffled, chosen);
+
+        unchecked {
+            ++state.shuffled;
+        }
+        return chosen;
+    }
 
     /**
-    @notice Returns the next value in the shuffle list in O(1) time and memory.
-    @dev NB: See the `dev` documentation of this contract re security (or lack
-    thereof) of deterministic shuffling.
+     * @notice Returns the next value in the shuffle list in O(1) time and
+     * memory together with the random number that was used for the drawing.
+     * @dev NB: See the `dev` documentation of this contract re security (or
+     * lack thereof) of deterministic shuffling.
      */
-    function _next(PRNG.Source src) internal returns (uint256) {
-        require(shuffled < numToShuffle, "NextShuffler: finished");
+    function nextWithRand(State storage state, PRNG.Source src)
+        internal
+        returns (uint256, uint256)
+    {
+        uint256 rand = src.readLessThan(state.numToShuffle - state.shuffled);
+        return (next(state, rand), rand);
+    }
 
-        uint256 j = src.readLessThan(numToShuffle - shuffled) + shuffled;
-        emit ShuffledWith(shuffled, j);
+    /**
+     * @notice Returns the next value in the shuffle list in O(1) time and
+     * memory.
+     * @dev NB: See the `dev` documentation of this contract re security (or
+     * lack thereof) of deterministic shuffling.
+     */
+    function next(State storage state, PRNG.Source src)
+        internal
+        returns (uint256)
+    {
+        (uint256 choice, ) = nextWithRand(state, src);
+        return choice;
+    }
 
-        uint256 chosen = _get(j);
-        _set(j, _get(shuffled));
-        shuffled++;
-        return chosen;
+    /**
+     * @notice Returns a flag that indicates if the entire list has been
+     * shuffled.
+     */
+    function finished(State storage state) internal view returns (bool) {
+        return state.shuffled >= state.numToShuffle;
+    }
+
+    /**
+     * @notice Restarts the shuffler, such that all elements can be drawn again.
+     * @dev Restarting does not clear the internal permutation. Running the
+     * the shuffle again with same seed after restarting might, therefore,
+     * yield different results.
+     */
+    function restart(State storage state) internal {
+        state.shuffled = 0;
+    }
+
+    /**
+     * @notice Resets the shuffler.
+     */
+    function reset(State storage state) internal {
+        uint256 shuffled = state.shuffled;
+        for (uint256 i; i < shuffled; ++i) {
+            state.permutation[i] = 0;
+        }
+        restart(state);
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@divergencetech/ethier",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "description": "Golang and Solidity SDK to make Ethereum development ethier",
   "main": "\"\"",
   "scripts": {

--- a/tests/random/TestableNextShuffler.sol
+++ b/tests/random/TestableNextShuffler.sol
@@ -14,7 +14,7 @@ contract TestableNextShuffler {
     uint256[] public permutation;
 
     /// @notice Emited on each call to _next() to allow for thorough testing.
-    event ShuffledWith(uint256 current, uint256 with);
+    event SwappedWith(uint256 current, uint256 with);
 
     constructor(uint256 numToShuffle) {
         state.init(numToShuffle);
@@ -25,8 +25,8 @@ contract TestableNextShuffler {
      */
     function _next(PRNG.Source src) internal returns (uint256) {
         uint256 shuffled = state.shuffled;
-        (uint256 choice, uint256 rand) = state.nextWithRand(src);
-        emit ShuffledWith(shuffled, shuffled + rand);
+        (uint256 choice, uint256 rand) = state.nextAndRand(src);
+        emit SwappedWith(shuffled, shuffled + rand);
         return choice;
     }
 

--- a/tests/random/nextshuffler_test.go
+++ b/tests/random/nextshuffler_test.go
@@ -40,8 +40,8 @@ func TestNextShuffler(t *testing.T) {
 			// Capture the random values used in the shuffle to (a) check invariants;
 			// and (b) reimplement regular Fisher–Yates shuffle for comparison with the
 			// contract output.
-			rand := make(chan *TestableNextShufflerShuffledWith)
-			shuffler.TestableNextShufflerFilterer.WatchShuffledWith(nil, rand)
+			rand := make(chan *TestableNextShufflerSwappedWith)
+			shuffler.TestableNextShufflerFilterer.WatchSwappedWith(nil, rand)
 			defer close(rand)
 
 			if _, err := shuffler.Permute(sim.Acc(0), tt.seed); err != nil {
@@ -85,10 +85,10 @@ func TestNextShuffler(t *testing.T) {
 			for i, j := range gotShuffles {
 				gotStationary = gotStationary || i == j
 				if i > j {
-					t.Errorf("Index %d shuffled with earlier index %d; want lookahead only", i, j)
+					t.Errorf("Index %d Swapped with earlier index %d; want lookahead only", i, j)
 				}
 				if uint64(j) >= tt.total {
-					t.Errorf("Index %d shuffled with out-of-range index %d; want within list of length %d", i, j, tt.total)
+					t.Errorf("Index %d Swapped with out-of-range index %d; want within list of length %d", i, j, tt.total)
 				}
 			}
 

--- a/tests/random/nextshuffler_test.go
+++ b/tests/random/nextshuffler_test.go
@@ -48,17 +48,21 @@ func TestNextShuffler(t *testing.T) {
 				t.Fatalf("Permute(%d) error %v", tt.seed, err)
 			}
 
-			var got []uint64
-			for i := uint64(0); i < tt.total; i++ {
-				n, err := shuffler.Permutation(nil, new(big.Int).SetUint64(i))
-				if err != nil {
-					t.Fatalf("Permutation(%d) error %v", i, err)
+			runShuffling := func() []uint64 {
+				var got []uint64
+				for i := uint64(0); i < tt.total; i++ {
+					n, err := shuffler.Permutation(nil, new(big.Int).SetUint64(i))
+					if err != nil {
+						t.Fatalf("Permutation(%d) error %v", i, err)
+					}
+					if !n.IsUint64() {
+						t.Fatalf("Permutation(%d).IsUint64() = false; want true", i)
+					}
+					got = append(got, n.Uint64())
 				}
-				if !n.IsUint64() {
-					t.Fatalf("Permutation(%d).IsUint64() = false; want true", i)
-				}
-				got = append(got, n.Uint64())
+				return got
 			}
+			got := runShuffling()
 
 			gotShuffles := make([]int, tt.total)
 			for i := uint64(0); i < tt.total; i++ {
@@ -86,6 +90,12 @@ func TestNextShuffler(t *testing.T) {
 				if uint64(j) >= tt.total {
 					t.Errorf("Index %d shuffled with out-of-range index %d; want within list of length %d", i, j, tt.total)
 				}
+			}
+
+			shuffler.Reset(sim.Acc(0))
+			got = runShuffling()
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("Permutation diff compared to regular Fisher–Yates (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Currently, `NextShuffler` is designed as a contract that users can inherit from. While this is convenient and easy to set up, it precludes the usage of multiple shufflers in the same contract. 

To solve this, the logic was moved to a library that acts on shufflers stored in storage to allow full flexibility + adding some functions to restart/reset shufflers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/divergencetech/ethier/72)
<!-- Reviewable:end -->
