### PR TITLE
Add `AccessControlEnumerable` to `ERC721ACommon`

### DIFF
--- a/contracts/erc721/BaseTokenURI.sol
+++ b/contracts/erc721/BaseTokenURI.sol
@@ -2,13 +2,13 @@
 // Copyright (c) 2021 the ethier authors (github.com/divergencetech/ethier)
 pragma solidity >=0.8.0 <0.9.0;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
+import {AccessControlEnumerable} from "../utils/AccessControlEnumerable.sol";
 
 /**
 @notice ERC721 extension that overrides the OpenZeppelin _baseURI() function to
 return a prefix that can be set by the contract owner.
  */
-contract BaseTokenURI is Ownable {
+contract BaseTokenURI is AccessControlEnumerable {
     /// @notice Base token URI used as a prefix by tokenURI().
     string public baseTokenURI;
 
@@ -17,7 +17,10 @@ contract BaseTokenURI is Ownable {
     }
 
     /// @notice Sets the base token URI prefix.
-    function setBaseTokenURI(string memory _baseTokenURI) public onlyOwner {
+    function setBaseTokenURI(string memory _baseTokenURI)
+        public
+        onlyRole(DEFAULT_STEERING_ROLE)
+    {
         baseTokenURI = _baseTokenURI;
     }
 

--- a/contracts/erc721/ERC721ACommon.sol
+++ b/contracts/erc721/ERC721ACommon.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import {ERC721A} from "erc721a/contracts/ERC721A.sol";
 import {ERC2981} from "@openzeppelin/contracts/token/common/ERC2981.sol";
-// import {AccessControlEnumerable} from "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 import {AccessControlEnumerable} from "../utils/AccessControlEnumerable.sol";
 import {AccessControlPausable} from "../utils/AccessControlPausable.sol";
 
@@ -14,6 +13,9 @@ import {AccessControlPausable} from "../utils/AccessControlPausable.sol";
  - ERC2981 royalties
  */
 contract ERC721ACommon is ERC721A, AccessControlPausable, ERC2981 {
+    /// @param admin Address granted DEFAULT_ADMIN_ROLE.
+    /// @param steerer Address allowed to make general modifications to contract
+    /// behaviour by being granted DEFAULT_STEERING_ROLE.
     constructor(
         address admin,
         address steerer,

--- a/contracts/erc721/ERC721ACommon.sol
+++ b/contracts/erc721/ERC721ACommon.sol
@@ -2,23 +2,29 @@
 // Copyright (c) 2022 the ethier authors (github.com/divergencetech/ethier)
 pragma solidity >=0.8.0 <0.9.0;
 
-import "erc721a/contracts/ERC721A.sol";
-import "../utils/OwnerPausable.sol";
-import "@openzeppelin/contracts/token/common/ERC2981.sol";
+import {ERC721A} from "erc721a/contracts/ERC721A.sol";
+import {ERC2981} from "@openzeppelin/contracts/token/common/ERC2981.sol";
+// import {AccessControlEnumerable} from "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
+import {AccessControlEnumerable} from "../utils/AccessControlEnumerable.sol";
+import {AccessControlPausable} from "../utils/AccessControlPausable.sol";
 
 /**
 @notice An ERC721A contract with common functionality:
  - Pausable with toggling functions exposed to Owner only
  - ERC2981 royalties
  */
-contract ERC721ACommon is ERC721A, OwnerPausable, ERC2981 {
+contract ERC721ACommon is ERC721A, AccessControlPausable, ERC2981 {
     constructor(
+        address admin,
+        address steerer,
         string memory name,
         string memory symbol,
         address payable royaltyReciever,
         uint96 royaltyBasisPoints
     ) ERC721A(name, symbol) {
         _setDefaultRoyalty(royaltyReciever, royaltyBasisPoints);
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        _grantRole(DEFAULT_STEERING_ROLE, steerer);
     }
 
     /// @notice Requires that the token exists.
@@ -52,12 +58,13 @@ contract ERC721ACommon is ERC721A, OwnerPausable, ERC2981 {
         public
         view
         virtual
-        override(ERC721A, ERC2981)
+        override(ERC721A, AccessControlEnumerable, ERC2981)
         returns (bool)
     {
         return
             ERC721A.supportsInterface(interfaceId) ||
-            ERC2981.supportsInterface(interfaceId);
+            ERC2981.supportsInterface(interfaceId) ||
+            AccessControlEnumerable.supportsInterface(interfaceId);
     }
 
     /// @notice Sets the royalty receiver and percentage (in units of basis
@@ -65,7 +72,7 @@ contract ERC721ACommon is ERC721A, OwnerPausable, ERC2981 {
     function setDefaultRoyalty(address receiver, uint96 basisPoints)
         public
         virtual
-        onlyOwner
+        onlyRole(DEFAULT_STEERING_ROLE)
     {
         _setDefaultRoyalty(receiver, basisPoints);
     }

--- a/contracts/utils/AccessControlEnumerable.sol
+++ b/contracts/utils/AccessControlEnumerable.sol
@@ -5,6 +5,9 @@ pragma solidity >=0.8.0 <0.9.0;
 import {AccessControlEnumerable as ACE} from "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 
 contract AccessControlEnumerable is ACE {
+    /// @notice The default role intended to perform access-restricted actions.
+    /// @dev We are using this instead of DEFAULT_ADMIN_ROLE because the latter
+    /// is intended to grant/revoke roles and will be secured differently.
     bytes32 public constant DEFAULT_STEERING_ROLE =
         keccak256("DEFAULT_STEERING_ROLE");
 

--- a/contracts/utils/AccessControlEnumerable.sol
+++ b/contracts/utils/AccessControlEnumerable.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2023 the ethier authors (github.com/divergencetech/ethier)
+pragma solidity >=0.8.0 <0.9.0;
+
+import {AccessControlEnumerable as ACE} from "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
+
+contract AccessControlEnumerable is ACE {
+    bytes32 public constant DEFAULT_STEERING_ROLE =
+        keccak256("DEFAULT_STEERING_ROLE");
+
+    /// @dev Overrides supportsInterface so that inheriting contracts can
+    /// reference this contract instead of OZ's version for further overrides.
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ACE)
+        returns (bool)
+    {
+        return ACE.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/utils/AccessControlPausable.sol
+++ b/contracts/utils/AccessControlPausable.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021 the ethier authors (github.com/divergencetech/ethier)
+pragma solidity >=0.8.0 <0.9.0;
+
+import {Pausable} from "@openzeppelin/contracts/security/Pausable.sol";
+import {AccessControlEnumerable} from "./AccessControlEnumerable.sol";
+
+/// @notice A Pausable contract that can only be toggled by a member of the
+/// STEERING role.
+contract AccessControlPausable is AccessControlEnumerable, Pausable {
+    /// @notice Pauses the contract.
+    function pause() public onlyRole(DEFAULT_STEERING_ROLE) {
+        Pausable._pause();
+    }
+
+    /// @notice Unpauses the contract.
+    function unpause() public onlyRole(DEFAULT_STEERING_ROLE) {
+        Pausable._unpause();
+    }
+}

--- a/ethtest/revert/revert.go
+++ b/ethtest/revert/revert.go
@@ -2,6 +2,10 @@
 package revert
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/h-fam/errdiff"
 )
 
@@ -20,6 +24,10 @@ const (
 	Paused             = Checker("Pausable: paused")
 	Reentrant          = Checker("ReentrancyGuard: reentrant call")
 )
+
+func MissingRole(account common.Address, role [32]byte) Checker {
+	return Checker(fmt.Sprintf("AccessControl: account %s is missing role 0x%x", strings.ToLower(account.Hex()), role))
+}
 
 // Checkers for ethier libraries and contracts.
 const (

--- a/ethtest/revert/revert.go
+++ b/ethtest/revert/revert.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/crypto"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/h-fam/errdiff"
 )
@@ -25,8 +27,17 @@ const (
 	Reentrant          = Checker("ReentrancyGuard: reentrant call")
 )
 
+// MissingRole returns a Checker that checks that a transaction reverts because the account requires but does not have the specified role.
 func MissingRole(account common.Address, role [32]byte) Checker {
 	return Checker(fmt.Sprintf("AccessControl: account %s is missing role 0x%x", strings.ToLower(account.Hex()), role))
+}
+
+// MissingRoleByName returns a Checker that checks that a transaction reverts because the account requires but does not have the specified role name.
+func MissingRoleByName(account common.Address, name string) Checker {
+	h := crypto.Keccak256([]byte(name))
+	var role [32]byte
+	copy(role[:], h)
+	return MissingRole(account, role)
 }
 
 // Checkers for ethier libraries and contracts.

--- a/tests/erc721/TestableERC721ACommon.sol
+++ b/tests/erc721/TestableERC721ACommon.sol
@@ -2,14 +2,22 @@
 // Copyright (c) 2021 the ethier authors (github.com/divergencetech/ethier)
 pragma solidity >=0.8.0 <0.9.0;
 
-import "../../contracts/erc721/ERC721ACommon.sol";
-import "../../contracts/erc721/BaseTokenURI.sol";
+import {ERC721ACommon, ERC721A} from "../../contracts/erc721/ERC721ACommon.sol";
+import {BaseTokenURI} from "../../contracts/erc721/BaseTokenURI.sol";
+import {AccessControlEnumerable} from "../../contracts/utils/AccessControlEnumerable.sol";
 
 /// @notice Exposes a functions modified with the modifiers under test.
 contract TestableERC721ACommon is ERC721ACommon, BaseTokenURI {
     // solhint-disable-next-line no-empty-blocks
     constructor(address payable royaltyReciever, uint96 royaltyBasisPoints)
-        ERC721ACommon("Token", "JRR", royaltyReciever, royaltyBasisPoints)
+        ERC721ACommon(
+            msg.sender,
+            msg.sender,
+            "Token",
+            "JRR",
+            royaltyReciever,
+            royaltyBasisPoints
+        )
         BaseTokenURI("")
     {} // solhint-disable-line no-empty-blocks
 
@@ -42,5 +50,18 @@ contract TestableERC721ACommon is ERC721ACommon, BaseTokenURI {
         returns (string memory)
     {
         return BaseTokenURI._baseURI();
+    }
+
+    /// @notice Overrides supportsInterface as required by inheritance.
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC721ACommon, AccessControlEnumerable)
+        returns (bool)
+    {
+        return
+            ERC721ACommon.supportsInterface(interfaceId) ||
+            AccessControlEnumerable.supportsInterface(interfaceId);
     }
 }


### PR DESCRIPTION
I left `OwnerPausable` in there mainly to avoid having to refactor the Sellers (which will get an overhaul anyway) and the `OpenSeaERC721Mintable` for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/divergencetech/ethier/77)
<!-- Reviewable:end -->
